### PR TITLE
feat(physiology): OATP1B1/ECM reconciliation — close XGBoost-CYP / ECM double-counting (#12 #13 #14)

### DIFF
--- a/data/physiology/reference_man.yaml
+++ b/data/physiology/reference_man.yaml
@@ -62,7 +62,12 @@ nodes:
       CES1: {mean: 8.0e7, cv: 0.47}   # Boberg 2017 PMC5267516: 1664 pmol/mg × 48000 mg microsomal
       CES2: {mean: 8.4e6, cv: 0.61}   # Boberg 2017 PMC5267516: 174 pmol/mg × 48000 mg microsomal
     transporters:
-      # OATP1B1 independent lognormal — Achour 2021 empirical r<0.3 vs CYPs
+      # OATP1B1 independent lognormal — Achour 2021 empirical r<0.3 vs CYPs.
+      # Anchor: pravastatin 40 mg PO Cmax 0.045 mg/L (FDA label) under
+      # ECM-only hepatic clearance (post-#12 metabolic_fraction=0 for
+      # pravastatin removes XGBoost-CYP / ECM double-counting).
+      # Calibration sweep 2026-05-02: FE 1.058 at 5.0e5
+      # (data/validation/oatp_ecm_abundance_calibration.json).
       OATP1B1: {mean: 5.0e5, cv: 0.484}
     ivive_scaling: 0.00006   # 60/1e6: converts uL/min -> L/h (MPPGL * organ_wt already in abundance)
 

--- a/data/transporters/cyp_clearance_overrides.json
+++ b/data/transporters/cyp_clearance_overrides.json
@@ -1,0 +1,27 @@
+{
+  "version": 1,
+  "description": "Per-drug metabolic-CLint scale factors for substrates whose XGBoost-predicted hepatocyte CLint is dominated by transporter uptake (OATP1B1, etc.) rather than intracellular CYP/UGT metabolism. When the ECM transporter path is active in the engine, the metabolic_fraction here scales the CYP/UGT enzyme_affinities derived from XGBoost CLint, preventing double-counting. Default for any drug not listed: 1.0 (no scaling).",
+  "rationale": "In vitro hepatocyte CLint integrates uptake + intracellular metabolism. For drugs that are predominantly transporter substrates with negligible intracellular metabolism (e.g. pravastatin), the entire XGBoost CLint reflects the OATP1B1 contribution; explicitly modeling that path via the engine's ECM machinery while also keeping the CYP-allocated affinities counts the same clearance twice. metabolic_fraction = 0 zeroes the metabolic path entirely; intermediate values (e.g. 0.7 for atorvastatin's mixed CYP3A4 + OATP1B1 mechanism) await per-drug literature curation in v0.3.",
+  "schema": {
+    "drug": "Lowercase common name (informational).",
+    "smiles": "Canonical SMILES (RDKit). Lookup matches by InChIKey to be robust to SMILES variants.",
+    "inchikey": "RDKit InChIKey (primary lookup key).",
+    "metabolic_fraction": "Float in [0, 1]. Multiplied into per-enzyme affinities by _decompose_clint when ECM transporter path is active. Default 1.0 = no scaling = current behavior.",
+    "literature": "References supporting the chosen fraction.",
+    "notes": "Free-form rationale."
+  },
+  "overrides": [
+    {
+      "drug": "pravastatin",
+      "smiles": "CC[C@@H](C)C(=O)O[C@@H]1C[C@@H](O)C=C2[C@@H](CC[C@@H](O)C[C@@H](O)CC(=O)O)[C@H](C)CC[C@@H]21",
+      "inchikey": "GOSGZXISMCZCDW-LYANWTNHSA-N",
+      "metabolic_fraction": 0.0,
+      "literature": [
+        "Hatorp 2002: pravastatin hepatic uptake is OATP1B1/2-mediated; minimal CYP3A4/2C9 contribution.",
+        "Niemi 2009 OATP review: pravastatin Km on OATP1B1 13.6 uM (Varma 2014); CYP-mediated metabolism minor.",
+        "Watanabe 2009: PS_inf 0.5-2.0 L/h literature range absorbs all hepatic clearance for pravastatin."
+      ],
+      "notes": "Pravastatin is the canonical OATP1B1-only substrate. Its XGBoost CLint already approximates total in vivo hepatic CL via uptake; adding the ECM OATP1B1 path on top double-counts. Setting metabolic_fraction=0 routes 100% of hepatic clearance through ECM, which the engine then scales via abundance × Jmax/Km × IVIVE."
+    }
+  ]
+}

--- a/data/validation/oatp_ecm_abundance_calibration.json
+++ b/data/validation/oatp_ecm_abundance_calibration.json
@@ -3,79 +3,79 @@
   "sweep": [
     {
       "abundance": 10000.0,
-      "cmax_mg_L": 0.14007904069234994,
+      "cmax_mg_L": 0.17441430960842955,
       "observed_cmax_mg_L": 0.045,
-      "fold_error": 3.11286757094111,
+      "fold_error": 3.87587354685399,
       "ps_active_L_per_h_linear_est": 10.058823529411766,
-      "wall_s": 0.10617399215698242
+      "wall_s": 0.12053537368774414
     },
     {
       "abundance": 100000.0,
-      "cmax_mg_L": 0.09018342762415024,
+      "cmax_mg_L": 0.09707601630361612,
       "observed_cmax_mg_L": 0.045,
-      "fold_error": 2.004076169425561,
+      "fold_error": 2.157244806747025,
       "ps_active_L_per_h_linear_est": 100.58823529411765,
-      "wall_s": 0.10255956649780273
+      "wall_s": 0.0961008071899414
     },
     {
       "abundance": 300000.0,
-      "cmax_mg_L": 0.05708930256986854,
+      "cmax_mg_L": 0.05920588587920313,
       "observed_cmax_mg_L": 0.045,
-      "fold_error": 1.268651168219301,
+      "fold_error": 1.3156863528711806,
       "ps_active_L_per_h_linear_est": 301.7647058823529,
-      "wall_s": 0.10505509376525879
+      "wall_s": 0.10627102851867676
     },
     {
       "abundance": 500000.0,
-      "cmax_mg_L": 0.045577669820701446,
+      "cmax_mg_L": 0.04759822702907022,
       "observed_cmax_mg_L": 0.045,
-      "fold_error": 1.0128371071266988,
+      "fold_error": 1.0577383784237826,
       "ps_active_L_per_h_linear_est": 502.94117647058823,
-      "wall_s": 0.10689711570739746
+      "wall_s": 0.1153111457824707
     },
     {
       "abundance": 700000.0,
-      "cmax_mg_L": 0.03975192237297458,
+      "cmax_mg_L": 0.04195666493200594,
       "observed_cmax_mg_L": 0.045,
-      "fold_error": 1.1320207253824117,
+      "fold_error": 1.072535199661985,
       "ps_active_L_per_h_linear_est": 704.1176470588235,
-      "wall_s": 0.11762452125549316
+      "wall_s": 0.11102437973022461
     },
     {
       "abundance": 1000000.0,
-      "cmax_mg_L": 0.03492550750964648,
+      "cmax_mg_L": 0.037414424290260206,
       "observed_cmax_mg_L": 0.045,
-      "fold_error": 1.288456581126872,
+      "fold_error": 1.2027446861373858,
       "ps_active_L_per_h_linear_est": 1005.8823529411765,
-      "wall_s": 0.10212373733520508
+      "wall_s": 0.09291291236877441
     },
     {
       "abundance": 3000000.0,
-      "cmax_mg_L": 0.026557339984777467,
+      "cmax_mg_L": 0.029766289579470296,
       "observed_cmax_mg_L": 0.045,
-      "fold_error": 1.6944468092735858,
+      "fold_error": 1.511777270051029,
       "ps_active_L_per_h_linear_est": 3017.6470588235293,
-      "wall_s": 0.08772611618041992
+      "wall_s": 0.09915685653686523
     },
     {
       "abundance": 10000000.0,
-      "cmax_mg_L": 0.02334722195915557,
+      "cmax_mg_L": 0.0268988582502812,
       "observed_cmax_mg_L": 0.045,
-      "fold_error": 1.927424174007706,
+      "fold_error": 1.6729334598999037,
       "ps_active_L_per_h_linear_est": 10058.823529411766,
-      "wall_s": 0.09123992919921875
+      "wall_s": 0.09358835220336914
     },
     {
       "abundance": 100000000.0,
-      "cmax_mg_L": 0.022065412816263258,
+      "cmax_mg_L": 0.025762501054732753,
       "observed_cmax_mg_L": 0.045,
-      "fold_error": 2.039390804727336,
+      "fold_error": 1.7467248193176952,
       "ps_active_L_per_h_linear_est": 100588.23529411765,
-      "wall_s": 0.10277080535888672
+      "wall_s": 0.08733415603637695
     }
   ],
   "recommended_abundance": 500000.0,
-  "recommended_fold_error": 1.0128371071266988,
+  "recommended_fold_error": 1.0577383784237826,
   "recommended_ps_active": 502.94117647058823,
   "ps_active_in_literature_range": false
 }

--- a/docs/claude/experiment-log.md
+++ b/docs/claude/experiment-log.md
@@ -1,5 +1,5 @@
 ---
-last_updated: 2026-04-30
+last_updated: 2026-05-02
 parent: ../../CLAUDE.md
 charter: Chronological log of Sisyphus experiments (successes, negatives, infrastructure). Latest first.
 ---
@@ -7,6 +7,37 @@ charter: Chronological log of Sisyphus experiments (successes, negatives, infras
 # Experiment Log
 
 Reverse-chronological. Top-level [CLAUDE.md](../../CLAUDE.md) carries only the **current** headline numbers; this file is the history. For the authoritative failed-experiment list (with do-not-retry gating), see [dead-ends.md](./dead-ends.md). For the why-accuracy-is-bounded analysis, see [diagnosis.md](./diagnosis.md).
+
+---
+
+## 2026-05-02 — OATP1B1/ECM reconciliation: XGBoost-CYP / ECM-OATP double-counting resolved (#12-#14)
+
+**Branch**: `feat/oatp1b1-ecm-reconciliation`
+**Trigger**: GenoADME Tier 1 PARTIAL on pravastatin; `test_oatp_ecm_statins[pravastatin]` xfail under post-Hardening realize_means() (FE drifted 1.486 → 1.823); GitHub issues #12 (#8a) / #13 (#8b) / #14 (#8c) sequencing the fix.
+
+**Root cause**: `build_drug_on_graph(profile, adme, ..., transporter_kinetics, hepatic_ecm_params)` always decomposed XGBoost hepatocyte CLint into per-enzyme affinities AND, separately, applied the OATP1B1 ECM clearance when transporter+ECM kwargs were supplied. The two clearances added at the simulation layer. For uptake-dominated substrates (canonical: pravastatin, ~85% OATP1B1), in vitro hepatocyte CLint already integrates the OATP1B1 contribution, so this counted the same clearance twice.
+
+**Fix**: Per-drug `metabolic_fraction` registry that scales the metabolic-path enzyme_affinities derived from XGBoost CLint. When the engine's ECM machinery is active for a drug whose hepatocyte CLint is uptake-dominated, the registry routes the entire hepatic clearance through the ECM transporter path without double-counting. Default 1.0 (no scaling) for the 106 unregistered holdout drugs.
+
+- `data/transporters/cyp_clearance_overrides.json` — registry seeded with pravastatin metabolic_fraction=0.0 (canonical OATP1B1-only).
+- `src/sisyphus/predict/cyp_clearance_overrides.py` — InChIKey-keyed loader.
+- `src/sisyphus/predict/ivive.py` — `_decompose_clint(metabolic_fraction=)` + `build_drug_on_graph` SMILES lookup.
+- 9 unit tests covering loader (canonical/variant/unregistered/invalid SMILES) and decompose path (default/zero/half/cv-invariance).
+
+**Test invariant redesign (#13)**: The pre-#12 `cmax_on/cmax_off < 0.95` invariant in `test_oatp_pravastatin` is mathematically incompatible with the post-fix model — with metabolic_fraction=0, the "off" arm has no hepatic clearance for pravastatin and Cmax goes very high. Replaced with SLCO1B1 EM/PM phenotype check: PM (OATP1B1 × 0.10) must raise Cmax vs EM. Empirical: `cmax_em=0.0422`, `cmax_pm=0.1280`, ratio=3.034 (clinical literature: ~2-3× AUC under PM).
+
+**Abundance recalibration (#14)**: `scripts/calibrate_oatp_abundance_ecm.py` post-#12 still recommends the existing `liver.transporters.OATP1B1.mean = 5.0e5` (FE 1.058 vs FDA pravastatin 0.045 mg/L). The Hardening-era T7 drift was a downstream symptom of the double-counting, not an abundance miscalibration. PS_active 502 L/h remains outside the Watanabe 2009 literature range [0.5, 2.0] — separate ECM IVIVE-scaling concern (DE-33 adjacent), not a #12 deliverable.
+
+**Concrete metric changes**:
+- `test_oatp_ecm_statins[pravastatin]`: xfail (FE 1.486-1.823) → **PASS** (FE 1.066, gate 1.3). Promoted out of `_KNOWN_PEFF_FAILS`.
+- pravastatin engine Cmax under ECM (40 mg PO): 0.0303 → 0.0422 mg/L; under SLCO1B1 PM: 0.128 mg/L.
+- pitavastatin: PASS (already, retained).
+- rosuvastatin/atorvastatin: xfail unchanged (Peff over-prediction, separate root cause).
+- fluvastatin: xfail unchanged (under-prediction, opposite direction; tracked in new issue #21).
+
+**Headline invariance**: `pipeline.predict.predict()` does not activate ECM/transporter machinery by default — `build_drug_on_graph` is called without `transporter_kinetics` or `hepatic_ecm_params`. The 107-holdout benchmark predicts via the default path, so the metabolic_fraction registry has zero effect on production AAFE. **4track artifact bit-identical pre-vs-post #12** (Meta 2.6947, Engine 3.7575, ML 3.0571). The fix is targeted at ECM-active code paths (GenoADME Tier 1, PGx-aware predictions, calibration script, integration tests).
+
+**Aftermath**: Issue #21 (fluvastatin under-prediction) opened to track the opposite-direction failure. The metabolic_fraction registry is extensible to (B)-flavor per-drug fractions in v0.3 (atorvastatin ~0.7 CYP3A4, rosuvastatin ~0.15 CYP, etc.) by adding entries; no further code changes required.
 
 ---
 

--- a/src/sisyphus/predict/cyp_clearance_overrides.py
+++ b/src/sisyphus/predict/cyp_clearance_overrides.py
@@ -1,0 +1,67 @@
+"""Per-drug metabolic-CLint scale factors for OATP1B1-mediated substrates.
+
+When the engine's ECM transporter path is active for a drug, the XGBoost
+hepatocyte CLint that was decomposed into per-enzyme affinities double-counts
+clearance — the in-vitro hepatocyte assay already includes uptake. This
+registry lets us scale the metabolic (CYP/UGT) affinities for known
+transporter-dominant substrates so the engine's ECM path provides the entire
+hepatic clearance without the metabolic path adding on top.
+
+Default for any drug not in the registry is 1.0 (no scaling = current
+behavior). Lookup is by canonical InChIKey (RDKit) for robustness against
+SMILES variants.
+
+Registry file: ``data/transporters/cyp_clearance_overrides.json``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import pathlib
+from functools import lru_cache
+
+logger = logging.getLogger(__name__)
+
+_REGISTRY_PATH = (
+    pathlib.Path(__file__).resolve().parent.parent.parent.parent
+    / "data"
+    / "transporters"
+    / "cyp_clearance_overrides.json"
+)
+
+
+@lru_cache(maxsize=1)
+def _load() -> dict[str, float]:
+    """Load the registry once and index by InChIKey → metabolic_fraction."""
+    if not _REGISTRY_PATH.exists():
+        logger.debug("cyp_clearance_overrides: registry not found at %s", _REGISTRY_PATH)
+        return {}
+    with _REGISTRY_PATH.open() as f:
+        data = json.load(f)
+    index: dict[str, float] = {}
+    for entry in data.get("overrides", []):
+        ikey = entry.get("inchikey")
+        frac = entry.get("metabolic_fraction")
+        if ikey is None or frac is None:
+            continue
+        index[ikey] = float(frac)
+    return index
+
+
+def lookup_metabolic_fraction(smiles: str) -> float:
+    """Return the metabolic_fraction for ``smiles``, or 1.0 if not registered.
+
+    Lookup is by RDKit InChIKey to be SMILES-variant-robust. If RDKit is
+    unavailable or the SMILES is invalid, returns 1.0 (default no-scaling
+    behavior, fail-safe).
+    """
+    try:
+        from rdkit import Chem
+    except ImportError:
+        return 1.0
+    mol = Chem.MolFromSmiles(smiles)
+    if mol is None:
+        return 1.0
+    ikey = Chem.MolToInchiKey(mol)
+    return _load().get(ikey, 1.0)

--- a/src/sisyphus/predict/ivive.py
+++ b/src/sisyphus/predict/ivive.py
@@ -224,6 +224,7 @@ def _decompose_clint(
     enzyme_abundances: dict[str, float] | None = None,
     substrate_enzymes: set[str] | None = None,
     ugt_enzymes: set[str] | None = None,
+    metabolic_fraction: float = 1.0,
 ) -> dict[str, Distribution]:
     """Decompose total hepatic CLint into per-enzyme affinities.
 
@@ -248,6 +249,13 @@ def _decompose_clint(
         ugt_enzymes: DrugBank UGT substrate annotations (Sisyphus
             UGT tags, e.g. ``{"UGT2B7", "UGT1A1"}``).  If provided,
             UGT fraction is allocated per annotation pattern.
+        metabolic_fraction: Scale factor in [0, 1] applied to all per-enzyme
+            affinities. Default 1.0 = no scaling (XGBoost CLint allocated in
+            full to the metabolic path). Used by drugs whose XGBoost
+            hepatocyte CLint is dominated by transporter uptake (e.g.
+            pravastatin) so the engine's ECM transporter path provides the
+            hepatic clearance without the metabolic path double-counting.
+            See ``predict/cyp_clearance_overrides.py``.
 
     Returns:
         Dict mapping enzyme tag -> CLint per pmol enzyme (uL/min/pmol)
@@ -265,8 +273,9 @@ def _decompose_clint(
         # affinity such that: abundance * affinity * ivive_scaling = CLint_hepatic * fm
         # affinity = (CLint_hepatic * fm) / (abundance * ivive_scaling)
         affinity = (clint_hepatic_l_per_h * fraction) / (abundance * _IVIVE_SCALING)
+        scaled_affinity = max(affinity, 0.0) * metabolic_fraction
         # Carry CLint's CV through to affinity
-        enzyme_affinity[enzyme] = Distribution(mean=max(affinity, 0.0), cv=clint.cv)
+        enzyme_affinity[enzyme] = Distribution(mean=scaled_affinity, cv=clint.cv)
 
     logger.debug(
         "CLint decomposition: %.1f uL/min/10^6 cells -> %.1f L/h hepatic, compound_type=%s, fm=%s",
@@ -601,12 +610,19 @@ def build_drug_on_graph(
     # degradation (2.861→3.090). UGT code retained but inactive.
     ugt_enzymes = None
 
+    # OATP1B1-substrate metabolic_fraction override: when ECM provides the
+    # hepatic transporter path for drugs whose hepatocyte CLint is uptake-
+    # dominated, scale the metabolic affinities to avoid double-counting.
+    from sisyphus.predict.cyp_clearance_overrides import lookup_metabolic_fraction
+    metabolic_fraction = lookup_metabolic_fraction(profile.smiles)
+
     # Decompose CLint to per-enzyme affinities (CYP + UGT)
     enzyme_affinity = _decompose_clint(
         adme.clint, profile.compound_type, profile.pka,
         enzyme_abundances=abundances,
         substrate_enzymes=substrate_enzymes,
         ugt_enzymes=ugt_enzymes,
+        metabolic_fraction=metabolic_fraction,
     )
 
     # Compute Kp for each tissue using selected method

--- a/tests/integration/test_oatp_ecm_statins.py
+++ b/tests/integration/test_oatp_ecm_statins.py
@@ -124,16 +124,20 @@ _FE_GATE: dict[str, float] = {
 # regression.  xfail strict=False: test runs, assertion is expected to fail; if
 # it unexpectedly passes (Peff model improved) the test turns green automatically.
 #
-# 2026-05-01 Hardening update: switched _simulate_cmax to realize_means(). This
-# invalidated the seed=42-calibrated T7 abundance for pravastatin (FE drifted
-# 1.486 → 1.823 under mean-only realization). Until T7 is recalibrated against
-# realize_means(), pravastatin is xfailed with strict=False.
-# fluvastatin moved to xfail too — pre-existing under-prediction (FE 4.79
-# under Hardening; opposite direction from rosuvastatin/atorvastatin over-
-# prediction). Root cause unknown but separate from Peff or ECM (Cmax
-# under-predicted ~5×; possibly OATP1B1 over-uptake or absorption under-
-# estimation specific to fluvastatin).
-_KNOWN_PEFF_FAILS = {"rosuvastatin", "atorvastatin", "fluvastatin", "pravastatin"}
+# 2026-05-02 #12 reconciliation: pravastatin promoted out of xfail. The
+# Hardening drift (FE 1.486 → 1.823) was a downstream symptom of the
+# XGBoost-CYP / ECM-OATP1B1 double-counting now resolved by the
+# metabolic_fraction=0 registry entry. At the unchanged abundance 5.0e5,
+# pravastatin Cmax is 0.0422 mg/L vs FDA 0.045 mg/L (FE 1.066, gate 1.3).
+# Calibration script (scripts/calibrate_oatp_abundance_ecm.py) confirms
+# 5.0e5 remains optimal; full sweep in
+# data/validation/oatp_ecm_abundance_calibration.json.
+#
+# fluvastatin stays xfail — pre-existing under-prediction (FE 4.79; opposite
+# direction from rosuvastatin/atorvastatin over-prediction). Tracked in
+# issue #21 as a separate problem (possibly OATP1B1 over-uptake on
+# fluvastatin specifically, or non-OATP1B1 hepatic transport).
+_KNOWN_PEFF_FAILS = {"rosuvastatin", "atorvastatin", "fluvastatin"}
 
 
 def _simulate_cmax(drug_name: str) -> tuple[float, float]:

--- a/tests/integration/test_oatp_pravastatin.py
+++ b/tests/integration/test_oatp_pravastatin.py
@@ -1,9 +1,25 @@
-"""Integration tests for OATP1B1 hepatic uptake.
+"""Integration tests for OATP1B1 hepatic uptake (post-#12 reconciliation).
+
+The pre-#12 invariant ``cmax_on/cmax_off < 0.95`` is mathematically
+incompatible with the post-reconciliation model: with the metabolic
+path zeroed for pravastatin (registry entry, see issue #12), the
+"off" arm (no transporter_kinetics, no ECM) has *no* hepatic
+clearance for pravastatin and Cmax goes very high; the "on" arm has
+ECM-only clearance. The two cannot be ordered in a way that
+preserves the original test's intent.
+
+Replacement (#13 B1): verify the phenotype path. Under SLCO1B1 PM
+(OATP1B1 activity x 0.10), pravastatin systemic Cmax must be HIGHER
+than under SLCO1B1 EM (x 1.00), because reduced hepatic uptake leaves
+more drug in venous blood. This is the canonical clinical observation
+that motivated SLCO1B1 PGx in the first place.
 
 Depends on:
 - data/physiology/reference_man.yaml having liver.transporters.OATP1B1
 - data/transporters/oatp1b1.json with pravastatin entry
-- predict/ivive.py supporting transporter_kinetics kwarg
+- data/transporters/cyp_clearance_overrides.json with pravastatin entry
+- predict/ivive.py supporting transporter_kinetics + metabolic_fraction
+- predict/phenotype.py for SLCO1B1 -> OATP1B1 abundance scaling
 """
 
 from __future__ import annotations
@@ -20,6 +36,7 @@ from sisyphus.graph.builder import build_from_yaml
 from sisyphus.predict.adme import predict_adme
 from sisyphus.predict.chemistry import compute_profile
 from sisyphus.predict.ivive import build_drug_on_graph
+from sisyphus.predict.phenotype import apply_phenotype_to_graph
 from sisyphus.predict.transporter_db import (
     load_hepatic_ecm_params,
     load_oatp1b1_kinetics,
@@ -33,10 +50,14 @@ _PRAVASTATIN = (
 
 
 def _simulate_cmax(drug, graph, t_end: float = 24.0) -> float:
-    """Run a deterministic ODE solve and return venous_blood Cmax."""
-    rng = np.random.default_rng(42)
-    realized_graph = graph.sample(rng)
-    realized_drug = drug.sample(rng)
+    """Run a deterministic ODE solve and return venous_blood Cmax.
+
+    Uses ``realize_means()`` (post-Hardening canonical deterministic path)
+    to be consistent with ``test_oatp_ecm_statins`` and the production
+    ``predict()`` default.
+    """
+    realized_graph = graph.realize_means()
+    realized_drug = drug.realize_means()
 
     compiler = ODECompiler()
     compiled = compiler.compile(realized_graph)
@@ -54,54 +75,61 @@ def _simulate_cmax(drug, graph, t_end: float = 24.0) -> float:
     return float(np.max(result.concentrations["venous_blood"]))
 
 
-@pytest.mark.slow
-def test_pravastatin_cmax_moves_with_oatp():
-    """Engine Cmax for pravastatin decreases when OATP1B1 kinetics AND
-    ECM parameters (biliary clearance + sinusoidal PS) are active vs off.
-
-    Under ECM (post 2026-04-20), OATP kinetics alone do not change Cmax
-    because the PS_passive/PS_eff defaults (1e6 L/h) collapse the model
-    to well-stirred algebraically. Meaningful hepatic extraction reduction
-    requires supplying ``hepatic_ecm_params`` (pravastatin: PS_passive=0.8,
-    PS_eff=0.8, CL_int_bile=45). In the "on" arm both are loaded; in the
-    "off" arm both are None → default well-stirred path.
-    """
-    graph = build_from_yaml(_PHYS)
+def _build_pravastatin(graph):
     profile = compute_profile(_PRAVASTATIN)
     adme = predict_adme(profile)
     liver_enzymes = {
         tag: dist.mean for tag, dist in graph.nodes["liver"].enzymes.items()
     }
-
-    drug_off = build_drug_on_graph(
-        profile, adme, dose_mg=40.0, route="oral",
-        liver_enzymes=liver_enzymes,
-        transporter_kinetics=None,
-        hepatic_ecm_params=None,
-    )
-    drug_on = build_drug_on_graph(
+    return build_drug_on_graph(
         profile, adme, dose_mg=40.0, route="oral",
         liver_enzymes=liver_enzymes,
         transporter_kinetics=load_oatp1b1_kinetics("pravastatin"),
         hepatic_ecm_params=load_hepatic_ecm_params("pravastatin"),
     )
 
-    cmax_off = _simulate_cmax(drug_off, graph)
-    cmax_on = _simulate_cmax(drug_on, graph)
 
-    print(f"\npravastatin: cmax_off={cmax_off:.4f}, cmax_on={cmax_on:.4f}, "
-          f"ratio={cmax_on / cmax_off:.3f}")
+@pytest.mark.slow
+def test_pravastatin_pm_higher_cmax_than_em():
+    """SLCO1B1 PM reduces hepatic OATP1B1 uptake -> higher systemic Cmax.
 
-    ratio = cmax_on / cmax_off
-    assert ratio < 0.95, (
-        f"expected OATP1B1 uptake + ECM params to reduce Cmax meaningfully, "
-        f"got cmax_off={cmax_off:.4f}, cmax_on={cmax_on:.4f}, ratio={ratio:.3f}"
+    Replaces the pre-#12 cmax_on/cmax_off invariant. Verifies that the
+    PGx integration path is wired end-to-end through the engine: the
+    apply_phenotype_to_graph hook scales the OATP1B1 abundance, the
+    engine's ECM machinery sees the scaled abundance via PS_active, and
+    the drop in hepatic uptake lifts Cmax.
+    """
+    graph_em = build_from_yaml(_PHYS)
+    graph_pm = apply_phenotype_to_graph(graph_em, {"SLCO1B1": "PM"})
+
+    drug_em = _build_pravastatin(graph_em)
+    drug_pm = _build_pravastatin(graph_pm)
+
+    cmax_em = _simulate_cmax(drug_em, graph_em)
+    cmax_pm = _simulate_cmax(drug_pm, graph_pm)
+
+    print(
+        f"\npravastatin SLCO1B1: cmax_em={cmax_em:.4f}, cmax_pm={cmax_pm:.4f}, "
+        f"ratio={cmax_pm / cmax_em:.3f}"
+    )
+
+    assert cmax_pm > cmax_em, (
+        "expected SLCO1B1 PM to raise pravastatin Cmax (less hepatic uptake), "
+        f"got cmax_em={cmax_em:.4f}, cmax_pm={cmax_pm:.4f}"
+    )
+    # Lower bound: PM must produce a meaningful uplift, not just numerical
+    # noise. CPIC PM activity = 0.10x EM, so we expect at least ~10%
+    # higher Cmax. Tighter clinical observation is ~2-3x but depends on
+    # absolute abundance calibration (#14).
+    assert cmax_pm / cmax_em > 1.10, (
+        "expected at least 10% Cmax increase under PM, "
+        f"got ratio {cmax_pm / cmax_em:.3f}"
     )
 
 
 @pytest.mark.slow
 def test_non_oatp_drug_unaffected_by_oatp_wiring():
-    """Morphine (no OATP1B1 substrate) → transporter_kinetics empty → MM inactive."""
+    """Morphine (no OATP1B1 substrate) -> transporter_kinetics empty -> MM inactive."""
     graph = build_from_yaml(_PHYS)
     morphine_smiles = "CN1CCC23C4C1CC5=C2C(=C(C=C5)O)OC3C(C=C4)O"
     profile = compute_profile(morphine_smiles)
@@ -117,9 +145,8 @@ def test_non_oatp_drug_unaffected_by_oatp_wiring():
     )
     assert drug.transporter_kinetics == {}, "morphine should not have OATP kinetics"
 
-    rng = np.random.default_rng(42)
-    realized_graph = graph.sample(rng)
-    realized_drug = drug.sample(rng)
+    realized_graph = graph.realize_means()
+    realized_drug = drug.realize_means()
 
     compiler = ODECompiler()
     compiled = compiler.compile(realized_graph)

--- a/tests/unit/test_cyp_clearance_overrides.py
+++ b/tests/unit/test_cyp_clearance_overrides.py
@@ -1,0 +1,95 @@
+"""Unit tests for the cyp_clearance_overrides registry + scaling path.
+
+These verify three contracts:
+
+1. Registry lookup is SMILES-variant-robust (matches by InChIKey).
+2. Default for any unregistered drug is 1.0 (no scaling, current behavior).
+3. ``_decompose_clint`` multiplies all per-enzyme affinities by the supplied
+   metabolic_fraction.
+
+End-to-end pravastatin / OATP1B1 reconciliation lives in the integration
+tests (``test_oatp_pravastatin``, ``test_oatp_ecm_statins``).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from sisyphus.core import Distribution
+from sisyphus.predict.cyp_clearance_overrides import lookup_metabolic_fraction
+from sisyphus.predict.ivive import _decompose_clint
+
+
+_PRAVASTATIN_CANONICAL = (
+    "CC[C@@H](C)C(=O)O[C@@H]1C[C@@H](O)C=C2[C@@H]"
+    "(CC[C@@H](O)C[C@@H](O)CC(=O)O)[C@H](C)CC[C@@H]21"
+)
+_PRAVASTATIN_VARIANT = (
+    "CC[C@@H](C)C(=O)O[C@@H]1C[C@H](C=C2[C@@H]1CC[C@H]"
+    "([C@@H]2CC[C@H](C[C@H](CC(=O)O)O)O)C)O"
+)
+_MORPHINE_SMILES = "CN1CCC23C4C1CC5=C2C(=C(C=C5)O)OC3C(C=C4)O"
+
+
+class TestLookupMetabolicFraction:
+    def test_pravastatin_canonical_returns_zero(self):
+        assert lookup_metabolic_fraction(_PRAVASTATIN_CANONICAL) == 0.0
+
+    def test_pravastatin_variant_smiles_returns_zero(self):
+        """Different SMILES of the same molecule must resolve via InChIKey."""
+        assert lookup_metabolic_fraction(_PRAVASTATIN_VARIANT) == 0.0
+
+    def test_unregistered_drug_returns_one(self):
+        assert lookup_metabolic_fraction(_MORPHINE_SMILES) == 1.0
+
+    def test_invalid_smiles_returns_one(self):
+        """Malformed input falls back to no-scaling (fail-safe)."""
+        assert lookup_metabolic_fraction("not a smiles") == 1.0
+
+    def test_empty_smiles_returns_one(self):
+        assert lookup_metabolic_fraction("") == 1.0
+
+
+class TestDecomposeClintScaling:
+    def _clint(self) -> Distribution:
+        return Distribution(mean=10.0, cv=0.3)
+
+    def test_default_fraction_one_unchanged(self):
+        """metabolic_fraction=1.0 must reproduce the legacy behavior."""
+        baseline = _decompose_clint(self._clint(), compound_type="acid", pka=4.0)
+        scaled = _decompose_clint(
+            self._clint(), compound_type="acid", pka=4.0,
+            metabolic_fraction=1.0,
+        )
+        assert set(baseline) == set(scaled)
+        for k in baseline:
+            assert baseline[k].mean == pytest.approx(scaled[k].mean)
+            assert baseline[k].cv == pytest.approx(scaled[k].cv)
+
+    def test_fraction_zero_yields_zero_affinities(self):
+        result = _decompose_clint(
+            self._clint(), compound_type="acid", pka=4.0,
+            metabolic_fraction=0.0,
+        )
+        assert result, "expected non-empty enzyme affinity dict"
+        for tag, dist in result.items():
+            assert dist.mean == 0.0, f"{tag} affinity must be zero"
+
+    def test_fraction_half_scales_proportionally(self):
+        baseline = _decompose_clint(self._clint(), compound_type="acid", pka=4.0)
+        half = _decompose_clint(
+            self._clint(), compound_type="acid", pka=4.0,
+            metabolic_fraction=0.5,
+        )
+        for tag in baseline:
+            assert half[tag].mean == pytest.approx(0.5 * baseline[tag].mean)
+
+    def test_cv_unchanged_by_scaling(self):
+        """CV propagates from CLint independent of the scale factor."""
+        clint = Distribution(mean=10.0, cv=0.42)
+        scaled = _decompose_clint(
+            clint, compound_type="acid", pka=4.0,
+            metabolic_fraction=0.3,
+        )
+        for dist in scaled.values():
+            assert dist.cv == pytest.approx(0.42)


### PR DESCRIPTION
## Summary
Closes the architectural double-counting that has been the dominant root cause of pravastatin Cmax over-extraction (xfail since 2026-04-22 ECM rollout, drifted further under 2026-05-01 Hardening). Implements approach (C+B hybrid) from issue #12: a per-drug \`metabolic_fraction\` registry that scales the XGBoost-CYP enzyme_affinities so substrates whose hepatocyte CLint is uptake-dominated route their entire hepatic clearance through the engine's ECM transporter path without the metabolic affinities adding on top.

Closes #12, closes #13, closes #14.

### Mechanism
In vitro hepatocyte CLint integrates uptake + intracellular metabolism. For drugs that are predominantly transporter substrates with negligible CYP/UGT contribution (canonical: pravastatin, ~85% OATP1B1), the entire XGBoost CLint reflects uptake; explicitly modeling that path via the engine's ECM machinery while also keeping the CYP-allocated affinities counts the same clearance twice.

### Concrete metric changes
| Test | Pre | Post | Δ |
|---|---|---|---|
| \`test_oatp_ecm_statins[pravastatin]\` | xfail FE 1.486-1.823 | **PASS** FE 1.066 | promoted out of \`_KNOWN_PEFF_FAILS\` |
| \`test_oatp_pravastatin\` (invariant) | \`cmax_on/cmax_off < 0.95\` | EM/PM ratio > 1.10 (got 3.034) | redesigned per #13 B1 |
| pravastatin engine Cmax (40 mg PO, ECM-on) | 0.0303 mg/L | 0.0422 mg/L | +39% (toward FDA 0.045) |
| pravastatin under SLCO1B1 PM | n/a | 0.128 mg/L | matches clinical ~3× EM |
| OATP1B1 abundance | 5.0e5 | **5.0e5** (unchanged) | calibration confirms FE 1.058 optimum |
| **107-holdout AAFE** (Meta) | **2.6947** | **2.6947** | **bit-identical** |
| **107-holdout AAFE** (Engine) | **3.7575** | **3.7575** | **bit-identical** |

### Why headline AAFE is invariant
\`pipeline.predict.predict()\` does not activate ECM/transporter machinery by default — \`build_drug_on_graph\` is called without \`transporter_kinetics\` or \`hepatic_ecm_params\`. The 107-holdout benchmark predicts via the default path, so the registry has zero effect on production. The fix is targeted at ECM-active code paths (GenoADME Tier 1, PGx-aware predictions, calibration script, integration tests).

### Commits (atomic)
1. \`feat(predict)\` — registry JSON + InChIKey loader + \`_decompose_clint(metabolic_fraction=)\` + \`build_drug_on_graph\` lookup + 9 unit tests. Closes #12.
2. \`test(integration)\` — \`test_oatp_pravastatin\` redesigned per #13 option B1 (SLCO1B1 EM/PM phenotype check). \`_simulate_cmax\` switched to \`realize_means()\` for Hardening alignment. Closes #13.
3. \`metric-change(physiology)\` — calibration script confirms abundance 5.0e5 unchanged; \`reference_man.yaml\` comment expanded; pravastatin removed from \`_KNOWN_PEFF_FAILS\`; calibration JSON regenerated. Closes #14.
4. \`docs\` — experiment-log entry.

### Aftermath
- Issue #21 opened to track fluvastatin under-prediction (FE 4.79, opposite direction). Cannot be addressed by single-abundance change; requires per-drug Jmax/Km override or non-OATP1B1 hepatic transport modeling.
- The metabolic_fraction registry is extensible to (B)-flavor per-drug fractions in v0.3 (atorvastatin ~0.7 CYP3A4, rosuvastatin ~0.15 CYP, etc.) by adding entries — no further code changes required.

## Test plan
- [x] 9 new unit tests (\`test_cyp_clearance_overrides.py\`) pass — loader robustness + decompose scaling
- [x] \`test_oatp_ecm_statins\`: 2 PASS (pravastatin, pitavastatin), 3 XFAIL (rosuvastatin/atorvastatin Peff over-pred, fluvastatin under-pred → #21)
- [x] \`test_oatp_pravastatin\`: 2 PASS (redesigned phenotype invariant, non-OATP morphine sanity)
- [x] \`test_slco1b1_phenotype\`: 3 PASS (regression check, no impact)
- [x] **704 pass / 15 skipped / 0 failed** across \`tests/unit/\` + \`tests/integration/test_engine_validation.py\` + \`tests/integration/test_holdout_regression.py\` (8m49s)
- [x] **107-holdout benchmark bit-identical** to pre-#12 (Meta 2.6947, Engine 3.7575, ML 3.0571)

## Refs
- Issue #12 root cause + 3-approach analysis
- Issue #13 mathematical incompatibility derivation
- Issue #14 abundance recalibration acceptance criteria
- Issue #21 (fluvastatin spawn-off)
- \`docs/claude/experiment-log.md\` 2026-05-02 entry
- \`scripts/calibrate_oatp_abundance_ecm.py\` regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)