### PR TITLE
feat(pipeline): kp_method= keyword on predict() — close hardening B3

### DIFF
--- a/docs/claude/hardening_backlog.md
+++ b/docs/claude/hardening_backlog.md
@@ -198,7 +198,7 @@ Total ~11-14 hours if no deviations. Each can ship independently; no item blocks
   - PI calibration logic (H3 follow-up) is added directly to `predict.py`
 - `B2` `merge_overlay()` implementation (no caller found in repo)
 - `C5` endpoint provenance (real inconsistency, but no downstream TDM/MIPD bug reported)
-- `B3` pipeline-level `kp_method` selection. `core.DrugOnGraph.kp_method` is a per-drug field declared in the architecture, but `pipeline.predict.predict()` calls `build_drug_on_graph(profile, adme, dose_mg, route)` without forwarding `kp_method`, so the function default `"rodgers_rowland"` always wins. Effect: Berezhkovskiy / Provided options are unreachable through the public API regardless of any per-drug configuration. Discovered by `feature/3d-cyp-multidist` Experiment C (2026-04-01, archive tag `archive/3d-cyp-multidist-2026-04-01`); self-assessed "small effect" (≤30/107 bases on holdout differ between RR and Berezhkovskiy). Reconsider when any trigger fires: a per-drug Berezhkovskiy override is requested, a Cmax regression is traced to base/zwitterion Kp, or the contract violation surfaces in code review.
+- ~~`B3` pipeline-level `kp_method` selection.~~ **Resolved 2026-05-02** — `pipeline.predict.predict()` now accepts a `kp_method=` keyword-only kwarg (default `"rodgers_rowland"`, preserves prior behavior bit-for-bit) and forwards it to both `build_drug_on_graph` call sites. Berezhkovskiy / Provided options are now reachable through the public API. 5 unit tests in `tests/unit/test_pipeline_kp_method.py` lock the wiring contract. Originally discovered by `feature/3d-cyp-multidist` Experiment C (archive tag `archive/3d-cyp-multidist-2026-04-01`).
 
 ---
 

--- a/src/sisyphus/pipeline/predict.py
+++ b/src/sisyphus/pipeline/predict.py
@@ -78,6 +78,7 @@ def predict(
     infusion_duration_min: float | None = None,
     *,
     phenotypes: dict[str, str] | None = None,
+    kp_method: str = "rodgers_rowland",
 ) -> PredictionResult:
     """End-to-end prediction: SMILES -> PredictionResult.
 
@@ -113,6 +114,16 @@ def predict(
             phenotype-conditional. ``None`` (default) is the
             average-patient prediction. See
             ``sisyphus.predict.phenotype.PHENOTYPE_SCALES``.
+        kp_method: Tissue partition coefficient (Kp) calculation method.
+            One of ``"rodgers_rowland"`` (default, suitable for most
+            small-molecule drugs), ``"berezhkovskiy"`` (alternative
+            ionization handling, differs from Rodgers-Rowland mainly for
+            bases and zwitterions), or ``"provided"`` (use values
+            supplied via ``DrugOnGraph.kp_overrides`` instead of
+            computing). Forwarded to ``build_drug_on_graph``; the prior
+            implementation hard-coded the default and made the per-drug
+            field unreachable through the public API (hardening backlog
+            B3, 2026-05-02).
 
     Returns:
         PredictionResult with combined PK endpoints and uncertainty.
@@ -154,7 +165,7 @@ def predict(
     # ── Step 1: Chemistry + ADME ─────────────────────────────────────────
     profile = compute_profile(smiles)
     adme = predict_adme(profile)
-    drug = build_drug_on_graph(profile, adme, dose_mg, route)
+    drug = build_drug_on_graph(profile, adme, dose_mg, route, kp_method=kp_method)
 
     # ── DrugBank enrichment tags ──────────────────────────────────────
     # NOTE: fup tag checks data availability + sanity range but does NOT
@@ -210,7 +221,11 @@ def predict(
             liver_enzymes: dict[str, float] = {
                 tag: dist.mean for tag, dist in graph.nodes["liver"].enzymes.items()
             }
-            drug = build_drug_on_graph(profile, adme, dose_mg, route, liver_enzymes=liver_enzymes)
+            drug = build_drug_on_graph(
+                profile, adme, dose_mg, route,
+                liver_enzymes=liver_enzymes,
+                kp_method=kp_method,
+            )
 
         from sisyphus.graph.builder import augment_for_active_species
         graph = augment_for_active_species(graph, drug)

--- a/tests/unit/test_pipeline_kp_method.py
+++ b/tests/unit/test_pipeline_kp_method.py
@@ -1,0 +1,95 @@
+"""Unit tests for the kp_method= parameter on pipeline.predict.predict.
+
+These verify that the parameter is threaded correctly through the pipeline
+to ``build_drug_on_graph``. Magnitude validation (does Berezhkovskiy
+produce different Cmax than Rodgers-Rowland?) belongs to integration
+tests; this file's job is the wiring contract only.
+
+Closes hardening backlog B3 (the per-drug DrugOnGraph.kp_method field
+was unreachable through pipeline.predict.predict() before 2026-05-02).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from sisyphus.core import PredictionResult
+from sisyphus.pipeline.predict import predict
+
+
+_CAFFEINE = "Cn1c(=O)c2c(ncn2C)n(C)c1=O"
+
+
+class TestPredictKpMethodWiring:
+    def test_default_is_rodgers_rowland(self):
+        """Existing callers (no kp_method kwarg) must continue to use
+        Rodgers-Rowland — the historical default and what every existing
+        benchmark / test expects.
+        """
+        baseline = predict(_CAFFEINE, dose_mg=100.0)
+        assert isinstance(baseline, PredictionResult)
+        assert baseline.pk.cmax.mean > 0
+
+    def test_default_call_unchanged(self):
+        """predict(smiles, dose) without kp_method must be bit-identical
+        to predict(smiles, dose, kp_method="rodgers_rowland").
+        """
+        a = predict(_CAFFEINE, dose_mg=100.0)
+        b = predict(_CAFFEINE, dose_mg=100.0, kp_method="rodgers_rowland")
+        assert a.pk.cmax.mean == pytest.approx(b.pk.cmax.mean)
+        assert a.pk.auc_0t.mean == pytest.approx(b.pk.auc_0t.mean)
+
+    def test_kp_method_is_keyword_only(self):
+        """kp_method must be keyword-only to keep the positional
+        signature stable for callers that pass route/n_mc_samples
+        positionally.
+        """
+        with pytest.raises(TypeError):
+            predict(_CAFFEINE, 100.0, "oral", 0, None, "rodgers_rowland")  # type: ignore[misc]
+
+    def test_kp_method_forwarded_to_build_drug_on_graph(self):
+        """The string passed to predict() must reach build_drug_on_graph.
+        Spying via patch — pipeline calls build_drug_on_graph twice
+        (initial + liver_enzymes rebuild); both calls must forward the
+        kp_method.
+        """
+        from sisyphus.predict import ivive
+
+        real_build = ivive.build_drug_on_graph
+        seen_kp_methods: list[str] = []
+
+        def spy(*args, **kwargs):
+            seen_kp_methods.append(kwargs.get("kp_method", "<missing>"))
+            return real_build(*args, **kwargs)
+
+        with patch("sisyphus.predict.ivive.build_drug_on_graph", side_effect=spy) as p:
+            predict(_CAFFEINE, dose_mg=100.0, kp_method="berezhkovskiy")
+            assert p.call_count >= 1, "expected build_drug_on_graph to be called at least once"
+            assert all(m == "berezhkovskiy" for m in seen_kp_methods), (
+                f"expected every build_drug_on_graph call to receive kp_method='berezhkovskiy', "
+                f"got {seen_kp_methods}"
+            )
+
+    def test_default_forwarded_to_build_drug_on_graph(self):
+        """Default kp_method='rodgers_rowland' must be forwarded explicitly
+        (not omitted), so the pipeline contract does not silently rely on
+        build_drug_on_graph's own default — that decoupling lets the
+        function default change without surprising the API.
+        """
+        from sisyphus.predict import ivive
+
+        real_build = ivive.build_drug_on_graph
+        seen_kp_methods: list[str] = []
+
+        def spy(*args, **kwargs):
+            seen_kp_methods.append(kwargs.get("kp_method", "<missing>"))
+            return real_build(*args, **kwargs)
+
+        with patch("sisyphus.predict.ivive.build_drug_on_graph", side_effect=spy):
+            predict(_CAFFEINE, dose_mg=100.0)
+            assert all(m == "rodgers_rowland" for m in seen_kp_methods), (
+                f"expected every call to receive kp_method='rodgers_rowland', "
+                f"got {seen_kp_methods}"
+            )


### PR DESCRIPTION
## Summary
Adds keyword-only \`kp_method\` parameter to \`pipeline.predict.predict()\` and forwards it to both \`build_drug_on_graph\` call sites, closing hardening backlog B3.

Before this change, the per-drug \`DrugOnGraph.kp_method\` field declared in the architecture was unreachable through the public \`predict()\` API — every call hard-coded the function default \`"rodgers_rowland"\`. Berezhkovskiy / Provided options worked only when a caller invoked \`build_drug_on_graph\` directly.

The mismatch was discovered by \`feature/3d-cyp-multidist\` Experiment C (2026-04-01, archive tag \`archive/3d-cyp-multidist-2026-04-01\`) and filed as B3 in the hardening backlog this session. Self-assessed effect is small (~30 bases on the 107-holdout differ between Rodgers-Rowland and Berezhkovskiy) but the contract violation was real.

## Changes
- \`src/sisyphus/pipeline/predict.py\` — \`kp_method: str = "rodgers_rowland"\` (keyword-only) on \`predict()\`, threaded into both \`build_drug_on_graph\` invocations (initial + liver_enzymes rebuild).
- \`tests/unit/test_pipeline_kp_method.py\` — 5 wiring tests:
  - default is \`"rodgers_rowland"\`
  - default-call bit-identical to explicit \`kp_method="rodgers_rowland"\`
  - keyword-only signature (positional rejection)
  - explicit value forwarded to both call sites (\`"berezhkovskiy"\`)
  - default value forwarded explicitly (decouples pipeline contract from \`build_drug_on_graph\` default)
- \`docs/claude/hardening_backlog.md\` — B3 entry struck through and marked resolved with implementation reference.

## Test plan
- [x] 5/5 new unit tests pass
- [x] \`tests/unit/test_pipeline_phenotypes.py\` 7/7 still pass (sibling kwarg, no interference)
- [x] \`tests/integration/test_engine_validation.py\` 12/12 still pass (default unchanged)
- [x] No metric change — default \`"rodgers_rowland"\` preserves all prior behavior bit-for-bit

## Refs
- B3 entry in \`docs/claude/hardening_backlog.md\` (Deferred YAGNI, now resolved)
- Original discovery: \`feature/3d-cyp-multidist\` Experiment C (archive tag \`archive/3d-cyp-multidist-2026-04-01\`)
- Sibling kwarg pattern: \`phenotypes=\` (PR #18)

🤖 Generated with [Claude Code](https://claude.com/claude-code)