### PR TITLE
feat(pipeline): auto-load OATP1B1 ECM kinetics for substrate SMILES (#9)

### DIFF
--- a/data/transporters/oatp1b1.json
+++ b/data/transporters/oatp1b1.json
@@ -2,45 +2,101 @@
   "transporter": "OATP1B1",
   "source_primary": "Varma 2014 JPET (pravastatin); Niemi 2009 review Km compilation (statins); Yang 2018 PMC6054689 (glimepiride Jmax); Chen 2018 PMID 29498478 (glimepiride Km)",
   "source_crosscheck": "Hirano 2004 DMD, Kameyama 2005 Pharmacogenetics Genomics, Kopplow 2005, Ho 2006 Gastro, Simonson 2004, Chen 2018 Basic Clin Pharmacol Toxicol",
-  "notes": "Phase 2A: pravastatin Jmax/Km verbatim from Varma 2014 Table 2. Rosuvastatin/atorvastatin/pitavastatin/fluvastatin Km values are midpoints of the ranges reported in the Niemi 2009 OATP review (primary sources cited per drug). Jmax values are literature-consistent estimates scaled from reported in vitro CLuptake ratios vs pravastatin (Hirano 2006, Maeda 2011, Li 2018 reviews) because primary Jmax values vary widely across HEK293-OATP1B1 vs hepatocyte systems. CVs widened to 0.40 (Jmax) / 0.35 (Km) to absorb this inter-study variability; the liver.transporters.OATP1B1 abundance constant (1.0e11, calibrated on pravastatin in Phase 1) absorbs residual bias, and the Bayesian update over drug.transporter_kinetics refines per-patient. Amendment v2 (2026-04-21, spec 6e7ce0a): substrate set = valsartan + glimepiride (N=2). Bosentan and repaglinide archived to dropped_under_amendment_v2. Glimepiride added to drugs with verified Km (Chen 2018) and Jmax (Yang 2018 PMC6054689). Amendment v2.1: valsartan promoted from blocked_drugs to drugs via flat-CLuptake Jmax scaling — Jmax_val = (228/13.6) × 1.39 = 23.3 pmol/min/mg, CV 0.70 (widened to absorb scaling uncertainty). blocked_drugs now empty.",
+  "notes": "Phase 2A: pravastatin Jmax/Km verbatim from Varma 2014 Table 2. Rosuvastatin/atorvastatin/pitavastatin/fluvastatin Km values are midpoints of the ranges reported in the Niemi 2009 OATP review (primary sources cited per drug). Jmax values are literature-consistent estimates scaled from reported in vitro CLuptake ratios vs pravastatin (Hirano 2006, Maeda 2011, Li 2018 reviews) because primary Jmax values vary widely across HEK293-OATP1B1 vs hepatocyte systems. CVs widened to 0.40 (Jmax) / 0.35 (Km) to absorb this inter-study variability; the liver.transporters.OATP1B1 abundance constant (1.0e11, calibrated on pravastatin in Phase 1) absorbs residual bias, and the Bayesian update over drug.transporter_kinetics refines per-patient. Amendment v2 (2026-04-21, spec 6e7ce0a): substrate set = valsartan + glimepiride (N=2). Bosentan and repaglinide archived to dropped_under_amendment_v2. Glimepiride added to drugs with verified Km (Chen 2018) and Jmax (Yang 2018 PMC6054689). Amendment v2.1: valsartan promoted from blocked_drugs to drugs via flat-CLuptake Jmax scaling \u2014 Jmax_val = (228/13.6) \u00d7 1.39 = 23.3 pmol/min/mg, CV 0.70 (widened to absorb scaling uncertainty). blocked_drugs now empty.",
   "drugs": {
     "pravastatin": {
-      "jmax_pmol_per_min_per_mg": {"mean": 228.0, "cv": 0.30},
-      "km_uM": {"mean": 13.6, "cv": 0.25},
-      "source": "Varma 2014 JPET Table 2"
+      "jmax_pmol_per_min_per_mg": {
+        "mean": 228.0,
+        "cv": 0.3
+      },
+      "km_uM": {
+        "mean": 13.6,
+        "cv": 0.25
+      },
+      "source": "Varma 2014 JPET Table 2",
+      "smiles": "CC[C@@H](C)C(=O)O[C@@H]1C[C@@H](O)C=C2[C@@H](CC[C@@H](O)C[C@@H](O)CC(=O)O)[C@H](C)CC[C@@H]21",
+      "inchikey": "GOSGZXISMCZCDW-LYANWTNHSA-N"
     },
     "rosuvastatin": {
-      "jmax_pmol_per_min_per_mg": {"mean": 170.0, "cv": 0.40},
-      "km_uM": {"mean": 6.5, "cv": 0.35},
-      "source": "Km: Niemi 2009 review (Simonson 2004, Ho 2006; range 4.0-7.3 μM). Jmax: scaled from rosuvastatin/pravastatin clinical hepatic uptake CL ratio ≈ 1.2 (Ho 2006 Gastro)."
+      "jmax_pmol_per_min_per_mg": {
+        "mean": 170.0,
+        "cv": 0.4
+      },
+      "km_uM": {
+        "mean": 6.5,
+        "cv": 0.35
+      },
+      "source": "Km: Niemi 2009 review (Simonson 2004, Ho 2006; range 4.0-7.3 \u03bcM). Jmax: scaled from rosuvastatin/pravastatin clinical hepatic uptake CL ratio \u2248 1.2 (Ho 2006 Gastro).",
+      "smiles": "CC(C)c1nc(N(C)S(C)(=O)=O)nc(-c2ccc(F)cc2)c1/C=C/[C@@H](O)C[C@@H](O)CC(=O)O",
+      "inchikey": "BPRHUIZQVSMCRT-VEUZHWNKSA-N"
     },
     "atorvastatin": {
-      "jmax_pmol_per_min_per_mg": {"mean": 250.0, "cv": 0.40},
-      "km_uM": {"mean": 12.4, "cv": 0.30},
-      "source": "Km: Kameyama 2005 (via Niemi 2009 review). Jmax: scaled from atorvastatin/pravastatin OATP1B1-specific uptake CL ratio ≈ 1.5 (Hirano 2006 review, excluding CYP3A4 contribution)."
+      "jmax_pmol_per_min_per_mg": {
+        "mean": 250.0,
+        "cv": 0.4
+      },
+      "km_uM": {
+        "mean": 12.4,
+        "cv": 0.3
+      },
+      "source": "Km: Kameyama 2005 (via Niemi 2009 review). Jmax: scaled from atorvastatin/pravastatin OATP1B1-specific uptake CL ratio \u2248 1.5 (Hirano 2006 review, excluding CYP3A4 contribution).",
+      "smiles": "CC(C)c1c(C(=O)Nc2ccccc2)c(-c2ccccc2)c(-c2ccc(F)cc2)n1CC[C@@H](O)C[C@@H](O)CC(=O)O",
+      "inchikey": "XUKUURHRXDUEBC-KAYWLYCHSA-N"
     },
     "pitavastatin": {
-      "jmax_pmol_per_min_per_mg": {"mean": 550.0, "cv": 0.40},
-      "km_uM": {"mean": 4.5, "cv": 0.35},
-      "source": "Km: Niemi 2009 review (Hirano 2004, Deng 2008; range 3.0-6.7 μM midpoint). Jmax: scaled from pitavastatin/pravastatin clinical hepatic uptake CL ratio ≈ 2.5 (Hirano 2004 DMD)."
+      "jmax_pmol_per_min_per_mg": {
+        "mean": 550.0,
+        "cv": 0.4
+      },
+      "km_uM": {
+        "mean": 4.5,
+        "cv": 0.35
+      },
+      "source": "Km: Niemi 2009 review (Hirano 2004, Deng 2008; range 3.0-6.7 \u03bcM midpoint). Jmax: scaled from pitavastatin/pravastatin clinical hepatic uptake CL ratio \u2248 2.5 (Hirano 2004 DMD).",
+      "smiles": "O=C(O)C[C@H](O)C[C@H](O)/C=C/c1c(C2CC2)nc2ccccc2c1-c1ccc(F)cc1",
+      "inchikey": "VGYFMXBACGZSIL-MCBHFWOFSA-N"
     },
     "fluvastatin": {
-      "jmax_pmol_per_min_per_mg": {"mean": 190.0, "cv": 0.40},
-      "km_uM": {"mean": 2.5, "cv": 0.35},
-      "source": "Km: Niemi 2009 review (Kopplow 2005, Noe 2007; range 1.4-3.5 μM midpoint). Jmax: scaled from fluvastatin/pravastatin OATP1B1-specific uptake CL ratio ≈ 1.3 (Kopplow 2005, excluding CYP2C9 contribution)."
+      "jmax_pmol_per_min_per_mg": {
+        "mean": 190.0,
+        "cv": 0.4
+      },
+      "km_uM": {
+        "mean": 2.5,
+        "cv": 0.35
+      },
+      "source": "Km: Niemi 2009 review (Kopplow 2005, Noe 2007; range 1.4-3.5 \u03bcM midpoint). Jmax: scaled from fluvastatin/pravastatin OATP1B1-specific uptake CL ratio \u2248 1.3 (Kopplow 2005, excluding CYP2C9 contribution).",
+      "smiles": "CC(C)n1c(/C=C/[C@H](O)C[C@H](O)CC(=O)O)c(-c2ccc(F)cc2)c2ccccc21",
+      "inchikey": "FJLGEFLZQAZZCD-JUFISIKESA-N"
     },
     "glimepiride": {
-      "jmax_pmol_per_min_per_mg": {"mean": 155.0, "cv": 0.40},
-      "km_uM": {"mean": 10.02, "cv": 0.30},
-      "source": "Km: Chen 2018 Basic Clin Pharmacol Toxicol PMID 29498478 (HEK293-OATP1B1 uptake assay; Km=10.02 ± 0.84 μM). Jmax: Yang 2018 Scientific Reports PMC6054689 Fig 5 (OATP1B1*1a-HEK293T; Vmax=155 ± 18.7 pmol/min/mg). Cross-check: single-molecule transport study (ScienceDirect 2025, pii/S1347861325000404) reports Km*1a=12.5 μM (consistent). CV widened to 0.40 (Jmax) / 0.30 (Km) per spec amendment v2.",
-      "amendment": "v2 2026-04-21 (spec 6e7ce0a)"
+      "jmax_pmol_per_min_per_mg": {
+        "mean": 155.0,
+        "cv": 0.4
+      },
+      "km_uM": {
+        "mean": 10.02,
+        "cv": 0.3
+      },
+      "source": "Km: Chen 2018 Basic Clin Pharmacol Toxicol PMID 29498478 (HEK293-OATP1B1 uptake assay; Km=10.02 \u00b1 0.84 \u03bcM). Jmax: Yang 2018 Scientific Reports PMC6054689 Fig 5 (OATP1B1*1a-HEK293T; Vmax=155 \u00b1 18.7 pmol/min/mg). Cross-check: single-molecule transport study (ScienceDirect 2025, pii/S1347861325000404) reports Km*1a=12.5 \u03bcM (consistent). CV widened to 0.40 (Jmax) / 0.30 (Km) per spec amendment v2.",
+      "amendment": "v2 2026-04-21 (spec 6e7ce0a)",
+      "smiles": "CCC1=C(C)CN(C(=O)NCCc2ccc(S(=O)(=O)NC(=O)NC3CCC(C)CC3)cc2)C1=O",
+      "inchikey": "WIGIZIANZCJQQY-UHFFFAOYSA-N"
     },
     "valsartan": {
-      "jmax_pmol_per_min_per_mg": {"mean": 23.3, "cv": 0.70},
-      "km_uM": {"mean": 1.39, "cv": 0.35},
-      "source": "Km: Niemi 2009 Pharmacol Ther 125:84-117 (PMC2765590) Table 2 (citing Yamashiro 2006 DMD 34:1247 + Maeda 2006). Jmax: scaled per spec amendment v2.1 flat-CLuptake methodology — Jmax_val = (Jmax_prava/Km_prava) × Km_val = (228/13.6) × 1.39 = 23.3 pmol/min/mg. CV 0.70 widened to absorb scaling uncertainty.",
+      "jmax_pmol_per_min_per_mg": {
+        "mean": 23.3,
+        "cv": 0.7
+      },
+      "km_uM": {
+        "mean": 1.39,
+        "cv": 0.35
+      },
+      "source": "Km: Niemi 2009 Pharmacol Ther 125:84-117 (PMC2765590) Table 2 (citing Yamashiro 2006 DMD 34:1247 + Maeda 2006). Jmax: scaled per spec amendment v2.1 flat-CLuptake methodology \u2014 Jmax_val = (Jmax_prava/Km_prava) \u00d7 Km_val = (228/13.6) \u00d7 1.39 = 23.3 pmol/min/mg. CV 0.70 widened to absorb scaling uncertainty.",
       "notes": "Jmax is SCALED, not primary-extracted. Primary source Yamashiro 2006 DMD paywalled; 15+ source attempts logged in prior oatp1b1.json commits and spec v2.1 documentation. Scaling methodology: flat OATP1B1 intrinsic activity assumed equal to pravastatin's. If valsartan's actual CLuptake > pravastatin's (as in pitavastatin/fluvastatin statin family), engine will over-predict Cmax. This is a known limitation of the v2.1 amendment.",
-      "amendment": "v2.1 2026-04-21 — promoted from blocked_drugs via flat-CLuptake scaling"
+      "amendment": "v2.1 2026-04-21 \u2014 promoted from blocked_drugs via flat-CLuptake scaling",
+      "smiles": "CCCCC(=O)N(Cc1ccc(-c2ccccc2-c2nnn[nH]2)cc1)[C@H](C(=O)O)C(C)C",
+      "inchikey": "ACWBQPMHZXGDFX-QFIPXVFZSA-N"
     }
   },
   "blocked_drugs": {
@@ -50,20 +106,33 @@
     "rationale": "Spec amendment 6e7ce0a (2026-04-21) restricts ECM generalization test set to N=2 (valsartan + glimepiride). Bosentan and repaglinide dropped from active substrate set. Kinetics remain unverified for both; archived here for auditability.",
     "bosentan": {
       "status": "BLOCKED",
-      "blocked_reason": "Jmax (Vmax) from Treiber 2007 DMD 35:1400-1407 is paywalled (DOI 10.1124/dmd.107.015230). No open-access secondary source compiles Vmax for bosentan OATP1B1. Km=44 µM is verified via PMC3632236 which quotes Treiber 2007 verbatim.",
-      "km_uM_verified": {"mean": 44.0, "cv": null, "source": "Treiber 2007 DMD 35:1400-1407 Table 2, confirmed via Molina et al. 2013 PMC3632236 (explicit quote). DOI 10.1124/dmd.107.015230."},
+      "blocked_reason": "Jmax (Vmax) from Treiber 2007 DMD 35:1400-1407 is paywalled (DOI 10.1124/dmd.107.015230). No open-access secondary source compiles Vmax for bosentan OATP1B1. Km=44 \u00b5M is verified via PMC3632236 which quotes Treiber 2007 verbatim.",
+      "km_uM_verified": {
+        "mean": 44.0,
+        "cv": null,
+        "source": "Treiber 2007 DMD 35:1400-1407 Table 2, confirmed via Molina et al. 2013 PMC3632236 (explicit quote). DOI 10.1124/dmd.107.015230."
+      },
       "jmax_pmol_per_min_per_mg_status": "BLOCKED",
       "sources_attempted": [
-        "PubMed abstract PMID 17496208 — abstract only, no kinetic data",
-        "PMC3632236 — cites Km=44 µM but does not report Vmax",
-        "PMC2765590 (Niemi 2009 review) — Table 2 reports Km only, no Jmax column",
-        "PMC3907537 — reports IC50, not Vmax",
-        "PMC3264873 — no bosentan kinetics",
-        "dmd.aspetjournals.org/content/35/8/1400 — 403 forbidden",
-        "Semantic Scholar PDF link — page empty",
-        "Google Scholar, ResearchGate — full text paywalled"
+        "PubMed abstract PMID 17496208 \u2014 abstract only, no kinetic data",
+        "PMC3632236 \u2014 cites Km=44 \u00b5M but does not report Vmax",
+        "PMC2765590 (Niemi 2009 review) \u2014 Table 2 reports Km only, no Jmax column",
+        "PMC3907537 \u2014 reports IC50, not Vmax",
+        "PMC3264873 \u2014 no bosentan kinetics",
+        "dmd.aspetjournals.org/content/35/8/1400 \u2014 403 forbidden",
+        "Semantic Scholar PDF link \u2014 page empty",
+        "Google Scholar, ResearchGate \u2014 full text paywalled"
       ],
-      "plan_expected_envelope": {"km_range_uM": [40.0, 50.0], "jmax_range": [40.0, 80.0]},
+      "plan_expected_envelope": {
+        "km_range_uM": [
+          40.0,
+          50.0
+        ],
+        "jmax_range": [
+          40.0,
+          80.0
+        ]
+      },
       "dropped": "amendment v2 2026-04-21"
     },
     "repaglinide": {
@@ -72,15 +141,24 @@
       "km_uM_verified": null,
       "jmax_pmol_per_min_per_mg_status": "BLOCKED",
       "sources_attempted": [
-        "PubMed abstract PMID 15961978 (Niemi 2005) — abstract only, in vivo PK study, no cell-line kinetics",
-        "PMC2765590 (Niemi 2009 review) — Table 2: repaglinide Km listed as '–' (not reported)",
-        "PMID 23307347 (mechanistic modeling) — abstract, cites OATP1B1 active uptake but no Km",
-        "Link Springer s11095-014-1333-3 — 303 redirect/no access",
-        "PMC3857053 — repaglinide cited as substrate, no kinetics table",
-        "Wiley ascpt.onlinelibrary.wiley.com/doi/abs/10.1016/j.clpt.2005.01.018 — paywalled",
-        "Google Scholar, ResearchGate — full text paywalled"
+        "PubMed abstract PMID 15961978 (Niemi 2005) \u2014 abstract only, in vivo PK study, no cell-line kinetics",
+        "PMC2765590 (Niemi 2009 review) \u2014 Table 2: repaglinide Km listed as '\u2013' (not reported)",
+        "PMID 23307347 (mechanistic modeling) \u2014 abstract, cites OATP1B1 active uptake but no Km",
+        "Link Springer s11095-014-1333-3 \u2014 303 redirect/no access",
+        "PMC3857053 \u2014 repaglinide cited as substrate, no kinetics table",
+        "Wiley ascpt.onlinelibrary.wiley.com/doi/abs/10.1016/j.clpt.2005.01.018 \u2014 paywalled",
+        "Google Scholar, ResearchGate \u2014 full text paywalled"
       ],
-      "plan_expected_envelope": {"km_range_uM": [0.3, 0.5], "jmax_range": [20.0, 50.0]},
+      "plan_expected_envelope": {
+        "km_range_uM": [
+          0.3,
+          0.5
+        ],
+        "jmax_range": [
+          20.0,
+          50.0
+        ]
+      },
       "dropped": "amendment v2 2026-04-21"
     }
   }

--- a/src/sisyphus/pipeline/predict.py
+++ b/src/sisyphus/pipeline/predict.py
@@ -156,6 +156,11 @@ def predict(
     from sisyphus.predict.adme import predict_adme
     from sisyphus.predict.chemistry import compute_profile
     from sisyphus.predict.ivive import build_drug_on_graph
+    from sisyphus.predict.transporter_db import (
+        find_oatp1b1_substrate_name,
+        load_hepatic_ecm_params,
+        load_oatp1b1_kinetics,
+    )
 
     warnings_list: list[str] = []
     cmax_90ci: tuple[float, float] | None = None
@@ -165,7 +170,31 @@ def predict(
     # ── Step 1: Chemistry + ADME ─────────────────────────────────────────
     profile = compute_profile(smiles)
     adme = predict_adme(profile)
-    drug = build_drug_on_graph(profile, adme, dose_mg, route, kp_method=kp_method)
+
+    # Auto-detect OATP1B1 substrate via canonical InChIKey lookup. Both
+    # transporter kinetics and hepatic ECM parameters are loaded only when
+    # the drug appears in BOTH registries (statins currently:
+    # pravastatin/rosuvastatin/atorvastatin/pitavastatin/fluvastatin).
+    # For drugs registered as OATP1B1 substrates without ECM params (e.g.
+    # glimepiride, valsartan), kinetics are loaded but ECM stays off — the
+    # ECM machinery requires both to function correctly.
+    auto_oatp_kinetics = None
+    auto_ecm_params = None
+    substrate_name = find_oatp1b1_substrate_name(profile.smiles)
+    if substrate_name is not None:
+        kin = load_oatp1b1_kinetics(substrate_name)
+        ecm = load_hepatic_ecm_params(substrate_name)
+        if kin is not None and ecm is not None:
+            auto_oatp_kinetics = kin
+            auto_ecm_params = ecm
+            warnings_list.append(f"oatp1b1:auto_ecm:{substrate_name}")
+
+    drug = build_drug_on_graph(
+        profile, adme, dose_mg, route,
+        kp_method=kp_method,
+        transporter_kinetics=auto_oatp_kinetics,
+        hepatic_ecm_params=auto_ecm_params,
+    )
 
     # ── DrugBank enrichment tags ──────────────────────────────────────
     # NOTE: fup tag checks data availability + sanity range but does NOT
@@ -225,6 +254,8 @@ def predict(
                 profile, adme, dose_mg, route,
                 liver_enzymes=liver_enzymes,
                 kp_method=kp_method,
+                transporter_kinetics=auto_oatp_kinetics,
+                hepatic_ecm_params=auto_ecm_params,
             )
 
         from sisyphus.graph.builder import augment_for_active_species

--- a/src/sisyphus/predict/transporter_db.py
+++ b/src/sisyphus/predict/transporter_db.py
@@ -26,6 +26,46 @@ def _load_oatp1b1_table() -> dict[str, dict]:
     return {k.lower(): v for k, v in data.get("drugs", {}).items()}
 
 
+@functools.lru_cache(maxsize=1)
+def _load_oatp1b1_inchikey_index() -> dict[str, str]:
+    """InChIKey-connectivity-block -> drug_name mapping for SMILES-based
+    substrate detection.
+
+    Keys are the first 14 characters of the InChIKey (the connectivity
+    block, stereo-independent). This makes the lookup robust to SMILES
+    sources that strip stereochemistry annotations (e.g. some reference
+    datasets). False positives across the 7 currently-registered
+    substrates are not a concern because all have distinct
+    connectivity.
+    """
+    table = _load_oatp1b1_table()
+    return {
+        entry["inchikey"][:14]: name
+        for name, entry in table.items()
+        if "inchikey" in entry
+    }
+
+
+def find_oatp1b1_substrate_name(smiles: str) -> str | None:
+    """Return the registered OATP1B1 substrate's drug name for *smiles*, or None.
+
+    Lookup is via the InChIKey connectivity block (first 14 chars), so
+    SMILES variants of the same molecule resolve regardless of whether
+    stereochemistry is fully annotated in the input. Returns None if
+    RDKit is unavailable, the SMILES is invalid, or the molecule is
+    not a registered OATP1B1 substrate.
+    """
+    try:
+        from rdkit import Chem
+    except ImportError:
+        return None
+    mol = Chem.MolFromSmiles(smiles)
+    if mol is None:
+        return None
+    ikey = Chem.MolToInchiKey(mol)
+    return _load_oatp1b1_inchikey_index().get(ikey[:14])
+
+
 def load_oatp1b1_kinetics(drug_name: str) -> dict[str, TransporterKinetics] | None:
     """Return ``{'OATP1B1': TransporterKinetics}`` for *drug_name*, or None.
 

--- a/tests/unit/test_predict_auto_ecm.py
+++ b/tests/unit/test_predict_auto_ecm.py
@@ -1,0 +1,155 @@
+"""Unit tests for OATP1B1 ECM auto-loading on pipeline.predict.predict.
+
+Closes issue #9. Previously, ``predict()`` did not activate the engine's
+ECM transporter machinery for known OATP1B1 substrates — callers had to
+construct the graph + drug + ECM kwargs manually. This caused
+``apply_phenotype_to_graph(graph, {"SLCO1B1": "PM"})`` to be a no-op
+through ``predict()`` even though the underlying engine path supported it.
+
+These tests verify the wiring contract: SMILES of a registered substrate
+must trigger auto-loading of both transporter kinetics and hepatic ECM
+parameters; a non-substrate SMILES must leave them None.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from sisyphus.predict.transporter_db import find_oatp1b1_substrate_name
+
+
+_PRAVASTATIN_CANONICAL = (
+    "CC[C@@H](C)C(=O)O[C@@H]1C[C@@H](O)C=C2[C@@H]"
+    "(CC[C@@H](O)C[C@@H](O)CC(=O)O)[C@H](C)CC[C@@H]21"
+)
+_PRAVASTATIN_VARIANT = (
+    "CC[C@@H](C)C(=O)O[C@@H]1C[C@H](C=C2[C@@H]1CC[C@H]"
+    "([C@@H]2CC[C@H](C[C@H](CC(=O)O)O)O)C)O"
+)
+_CAFFEINE = "Cn1c(=O)c2c(ncn2C)n(C)c1=O"
+_MORPHINE = "CN1CCC23C4C1CC5=C2C(=C(C=C5)O)OC3C(C=C4)O"
+
+
+class TestFindOatp1b1Substrate:
+    def test_pravastatin_canonical_returns_name(self):
+        assert find_oatp1b1_substrate_name(_PRAVASTATIN_CANONICAL) == "pravastatin"
+
+    def test_pravastatin_variant_smiles_returns_name(self):
+        """SMILES variants of the same molecule must resolve via InChIKey."""
+        assert find_oatp1b1_substrate_name(_PRAVASTATIN_VARIANT) == "pravastatin"
+
+    def test_stereo_stripped_smiles_resolves_via_connectivity_block(self):
+        """Reference datasets (e.g. clinical_pk.json) sometimes carry
+        SMILES without stereochemistry annotations. The lookup must
+        resolve such variants via the InChIKey connectivity block (first
+        14 chars).
+        """
+        # Atorvastatin without stereo annotations (PubChem canonical
+        # without @ markers).
+        atorvastatin_no_stereo = (
+            "CC(C)C1=C(C(=O)NC2=CC=CC=C2)C(=C(N1CCC(O)CC(O)CC(=O)O)"
+            "C3=CC=C(F)C=C3)C4=CC=CC=C4"
+        )
+        assert find_oatp1b1_substrate_name(atorvastatin_no_stereo) == "atorvastatin"
+
+    def test_caffeine_not_a_substrate(self):
+        assert find_oatp1b1_substrate_name(_CAFFEINE) is None
+
+    def test_morphine_not_a_substrate(self):
+        assert find_oatp1b1_substrate_name(_MORPHINE) is None
+
+    def test_invalid_smiles_returns_none(self):
+        assert find_oatp1b1_substrate_name("not a smiles") is None
+
+    def test_empty_smiles_returns_none(self):
+        assert find_oatp1b1_substrate_name("") is None
+
+    def test_all_seven_registered_substrates_resolvable(self):
+        """The 7 substrate entries (pravastatin, rosuvastatin, atorvastatin,
+        pitavastatin, fluvastatin, glimepiride, valsartan) all have InChIKey
+        fields and resolve.
+        """
+        from sisyphus.predict.transporter_db import _load_oatp1b1_table
+        for name, entry in _load_oatp1b1_table().items():
+            assert "inchikey" in entry, f"{name} missing inchikey field"
+            assert "smiles" in entry, f"{name} missing smiles field"
+            resolved = find_oatp1b1_substrate_name(entry["smiles"])
+            assert resolved == name, f"round-trip failed for {name}: {resolved}"
+
+
+class TestPredictAutoEcmWiring:
+    def test_non_substrate_does_not_trigger_auto_load(self):
+        """Caffeine is not an OATP1B1 substrate. predict() must build the
+        drug without transporter_kinetics or hepatic_ecm_params.
+        """
+        from sisyphus.predict import ivive
+
+        real_build = ivive.build_drug_on_graph
+        captured: list[dict] = []
+
+        def spy(*args, **kwargs):
+            captured.append({
+                "transporter_kinetics": kwargs.get("transporter_kinetics"),
+                "hepatic_ecm_params": kwargs.get("hepatic_ecm_params"),
+            })
+            return real_build(*args, **kwargs)
+
+        from sisyphus.pipeline.predict import predict
+        with patch("sisyphus.predict.ivive.build_drug_on_graph", side_effect=spy):
+            predict(_CAFFEINE, dose_mg=100.0)
+        assert captured, "expected build_drug_on_graph to be invoked"
+        assert all(c["transporter_kinetics"] is None for c in captured)
+        assert all(c["hepatic_ecm_params"] is None for c in captured)
+
+    def test_pravastatin_triggers_auto_load(self):
+        """Pravastatin is in both oatp1b1.json and hepatic_ecm.json, so
+        predict() must auto-load both registries and forward to every
+        build_drug_on_graph call.
+        """
+        from sisyphus.predict import ivive
+
+        real_build = ivive.build_drug_on_graph
+        captured: list[dict] = []
+
+        def spy(*args, **kwargs):
+            captured.append({
+                "transporter_kinetics": kwargs.get("transporter_kinetics"),
+                "hepatic_ecm_params": kwargs.get("hepatic_ecm_params"),
+            })
+            return real_build(*args, **kwargs)
+
+        from sisyphus.pipeline.predict import predict
+        with patch("sisyphus.predict.ivive.build_drug_on_graph", side_effect=spy):
+            result = predict(_PRAVASTATIN_VARIANT, dose_mg=40.0)
+        assert captured, "expected build_drug_on_graph to be invoked"
+        assert all(c["transporter_kinetics"] is not None for c in captured), (
+            "expected every build_drug_on_graph call to receive auto-loaded kinetics"
+        )
+        assert all(c["hepatic_ecm_params"] is not None for c in captured), (
+            "expected every build_drug_on_graph call to receive auto-loaded ECM params"
+        )
+        assert "oatp1b1:auto_ecm:pravastatin" in result.warnings, (
+            f"expected auto_ecm warning tag, got {result.warnings}"
+        )
+
+    def test_pravastatin_auto_ecm_lifts_cmax_vs_caffeine_baseline(self):
+        """Sanity: with ECM auto-loaded, pravastatin Cmax through predict()
+        must be in the same magnitude family as the integration test
+        (~0.04 mg/L for 40 mg PO) rather than the pre-#9 value (~0.01 mg/L
+        with no hepatic clearance path because metabolic_fraction=0 zeroed
+        CYP and ECM was not active).
+
+        This is a smoke gate, not a tight calibration assertion — the exact
+        value depends on graph realization details that we don't lock here.
+        """
+        from sisyphus.pipeline.predict import predict
+        result = predict(_PRAVASTATIN_VARIANT, dose_mg=40.0)
+        assert result.pk.cmax.mean > 0.020, (
+            f"expected pravastatin Cmax > 0.02 mg/L with auto-ECM, got {result.pk.cmax.mean:.4f}"
+        )
+        assert result.pk.cmax.mean < 0.200, (
+            f"expected pravastatin Cmax < 0.2 mg/L (sanity upper bound), "
+            f"got {result.pk.cmax.mean:.4f}"
+        )


### PR DESCRIPTION
Closes #9.

## Summary
\`pipeline.predict.predict()\` now auto-detects registered OATP1B1 substrates by canonical InChIKey and loads both \`transporter_kinetics\` + \`hepatic_ecm_params\` from the existing \`oatp1b1.json\` + \`hepatic_ecm.json\` registries. Previously, the convenience wrapper was ECM-blind and callers had to construct the graph + drug + ECM kwargs manually (GenoADME route (b)).

This unblocks GenoADME's per-individual PGx orchestration to delegate to \`predict()\` instead of reimplementing engine wiring, and makes the metabolic_fraction registry from PR #22 actually reach OATP1B1 substrates through the public API.

## Implementation
- \`data/transporters/oatp1b1.json\`: each of 7 drug entries now carries canonical SMILES + InChIKey for SMILES-based reverse lookup.
- \`transporter_db.find_oatp1b1_substrate_name(smiles)\`: returns registered drug name via InChIKey block 1 (connectivity-only, 14 chars) so SMILES variants with stripped or differing stereochemistry still resolve. False positives are not a concern for the 7 substrates (all distinct connectivity).
- \`pipeline.predict.predict()\`: calls \`find_oatp1b1_substrate_name(profile.smiles)\`; if it returns a name AND that name has both \`oatp1b1\` + \`hepatic_ecm\` entries, both kwargs are auto-loaded and forwarded to every \`build_drug_on_graph\` invocation. Drugs registered without ECM params (glimepiride, valsartan) do not auto-load — both registries are required.
- A \`oatp1b1:auto_ecm:<name>\` tag is appended to \`result.warnings\` for audit.

## Headline impact: bit-identical 107-holdout AAFE

| Track | Pre | Post | Δ |
|---|---|---|---|
| Meta | 2.6947 | 2.6947 | 0 |
| Engine | 3.7575 | 3.7575 | 0 |
| ML | 3.0571 | 3.0571 | 0 |

**Why no change despite pravastatin being in holdout:** the \`clinical_pk.json\` reference SMILES for pravastatin is a different molecule at the connectivity level than the PubChem-canonical SMILES in the registry (block 1 \`TUZYXOIXSAXUGO\` vs \`GOSGZXISMCZCDW\` — extra ring double bond in the reference). This is a real data quality issue tracked in **issue #25** as a separate fix. The wiring works correctly, the holdout entry needs the SMILES correction first to benefit.

Verified by direct \`predict()\` call on PubChem-canonical pravastatin SMILES: Cmax \`0.0136 -> 0.0626\` mg/L with auto-ECM active. So the wiring is sound; only the reference data needs cleanup before the headline metric moves.

## Test plan
- [x] 11 new unit tests in \`tests/unit/test_predict_auto_ecm.py\` pass:
  - canonical / variant / stereo-stripped substrate SMILES all resolve
  - caffeine / morphine / invalid / empty SMILES all return None
  - all 7 registered substrates round-trip cleanly
  - non-substrate predict() does not auto-load
  - pravastatin predict() auto-loads both kwargs into every \`build_drug_on_graph\` call + sets the \`oatp1b1:auto_ecm:pravastatin\` warning tag
  - pravastatin Cmax magnitude sane (~0.04 mg/L) post-auto-load
- [x] 107-holdout benchmark bit-identical (Meta/Engine/ML all unchanged)
- [x] No regression on \`test_oatp_pravastatin\`, \`test_oatp_ecm_statins\`, \`test_slco1b1_phenotype\` (these already activate ECM directly)

## Refs
- Issue #9 (this PR closes)
- Issue #25 (clinical_pk.json pravastatin connectivity fix — spawn-off)
- PR #22 (OATP1B1/ECM reconciliation — set up the metabolic_fraction registry that this PR makes reachable through predict())
- PR #23 (\`kp_method=\` keyword — sibling kwarg pattern)
- PR #18 (\`phenotypes=\` keyword — sibling kwarg pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)