### PR TITLE
feat: promote pitavastatin to ecm_applicable=true (v0.3.1)

### DIFF
--- a/data/transporters/cyp_clearance_overrides.json
+++ b/data/transporters/cyp_clearance_overrides.json
@@ -21,7 +21,19 @@
         "Niemi 2009 OATP review: pravastatin Km on OATP1B1 13.6 uM (Varma 2014); CYP-mediated metabolism minor.",
         "Watanabe 2009: PS_inf 0.5-2.0 L/h literature range absorbs all hepatic clearance for pravastatin."
       ],
-      "notes": "Pravastatin is the canonical OATP1B1-only substrate. Its XGBoost CLint already approximates total in vivo hepatic CL via uptake; adding the ECM OATP1B1 path on top double-counts. Setting metabolic_fraction=0 routes 100% of hepatic clearance through ECM, which the engine then scales via abundance × Jmax/Km × IVIVE."
+      "notes": "Pravastatin is the canonical OATP1B1-only substrate. Its XGBoost CLint already approximates total in vivo hepatic CL via uptake; adding the ECM OATP1B1 path on top double-counts. Setting metabolic_fraction=0 routes 100% of hepatic clearance through ECM, which the engine then scales via abundance \u00d7 Jmax/Km \u00d7 IVIVE."
+    },
+    {
+      "drug": "pitavastatin",
+      "smiles": "O=C(O)C[C@H](O)C[C@H](O)/C=C/c1c(C2CC2)nc2ccccc2c1-c1ccc(F)cc1",
+      "inchikey": "VGYFMXBACGZSIL-MCBHFWOFSA-N",
+      "metabolic_fraction": 0.0,
+      "literature": [
+        "Niemi 2009 OATP review: pitavastatin SLCO1B1 PM/EM Cmax ratio ~3x \u2014 among the most OATP-rate-limited statins clinically (Hirano 2004 DMD; Deng 2008).",
+        "Hirano 2004 DMD 32:1162-7: pitavastatin OATP1B1 hepatic uptake CL ratio ~2.5x pravastatin in vitro.",
+        "Fujino 2004 J Pharm Sci 93:1019-26: ~80% biliary excretion (parent + glucuronide); minor CYP2C9 4-OH metabolism (~5-10%); UGT1A3/2B7 lactonization is reversible via paraoxonase. Intracellular metabolism not rate-limiting."
+      ],
+      "notes": "Pitavastatin parallels pravastatin: OATP1B1 hepatic uptake is rate-limiting (Niemi 2009 PM/EM ~3x); intracellular CYP2C9 + UGT1A3/2B7 paths are downstream of uptake and thus not rate-limiting at the whole-organ level. Setting metabolic_fraction=0 routes all hepatic CL through ECM (OATP1B1 saturable + ECM passive + biliary CL_int). EMPIRICAL NOTE: setting mf=0 vs mf=1.0 changes pitavastatin Cmax by <2% (sweep 2026-05-04), so the metabolic_fraction value is mechanistically chosen rather than empirically tuned. The residual ~2x under-prediction (Cmax 0.00168 vs FDA 0.0035) reflects Jmax/PS calibration uncertainty (Hirano 2004 scaled-from-pravastatin estimate carries 2x literature range), not metabolic_fraction error. v0.3.x parameter recalibration tracked separately."
     }
   ]
 }

--- a/data/transporters/oatp1b1.json
+++ b/data/transporters/oatp1b1.json
@@ -55,7 +55,8 @@
       },
       "source": "Km: Niemi 2009 review (Hirano 2004, Deng 2008; range 3.0-6.7 \u03bcM midpoint). Jmax: scaled from pitavastatin/pravastatin clinical hepatic uptake CL ratio \u2248 2.5 (Hirano 2004 DMD).",
       "smiles": "O=C(O)C[C@H](O)C[C@H](O)/C=C/c1c(C2CC2)nc2ccccc2c1-c1ccc(F)cc1",
-      "inchikey": "VGYFMXBACGZSIL-MCBHFWOFSA-N"
+      "inchikey": "VGYFMXBACGZSIL-MCBHFWOFSA-N",
+      "ecm_applicable": true
     },
     "fluvastatin": {
       "jmax_pmol_per_min_per_mg": {

--- a/docs/claude/experiment-log.md
+++ b/docs/claude/experiment-log.md
@@ -1,5 +1,5 @@
 ---
-last_updated: 2026-05-03
+last_updated: 2026-05-04
 parent: ../../CLAUDE.md
 charter: Chronological log of Sisyphus experiments (successes, negatives, infrastructure). Latest first.
 ---
@@ -7,6 +7,49 @@ charter: Chronological log of Sisyphus experiments (successes, negatives, infras
 # Experiment Log
 
 Reverse-chronological. Top-level [CLAUDE.md](../../CLAUDE.md) carries only the **current** headline numbers; this file is the history. For the authoritative failed-experiment list (with do-not-retry gating), see [dead-ends.md](./dead-ends.md). For the why-accuracy-is-bounded analysis, see [diagnosis.md](./diagnosis.md).
+
+---
+
+## 2026-05-04 — v0.3.1 pitavastatin ecm_applicable promotion
+
+**Branch**: `feat/pitavastatin-ecm-applicable` (PR pending)
+**Spawn**: v0.3 (PR #29) follow-up — initial seed list was pravastatin only; pitavastatin promotion was deferred pending `metabolic_fraction` curation.
+
+### What shipped
+
+Pitavastatin promoted to `ecm_applicable=true` in `data/transporters/oatp1b1.json`. Paired entry added to `data/transporters/cyp_clearance_overrides.json` with `metabolic_fraction=0` (parallel pravastatin justification: Niemi 2009 PM/EM ~3x makes pitavastatin among the most OATP-rate-limited statins clinically; intracellular CYP2C9 + UGT1A3/2B7 paths are downstream of the rate-limiting uptake step). Schema regression test seed list updated to `frozenset({"pravastatin", "pitavastatin"})`.
+
+### Empirical observation: metabolic_fraction is mechanistic, not empirical
+
+Sweep across `mf ∈ [0.0, 0.05, 0.10, 0.15, 0.25, 0.50, 1.0]` (2026-05-04, on `feat/pitavastatin-ecm-applicable`): pitavastatin Cmax varies from 0.00168 → 0.00165 mg/L (1.8% relative variation). The triple-counting hypothesis from PR #22 / PR #29 narrative does NOT apply meaningfully to pitavastatin — `mf` is a near-irrelevant knob for this drug.
+
+This **revises the v0.3 PR #29 narrative** retroactively: the pre-v0.3 (buggy auto-ECM) → post-v0.3 (no-ECM) flip on pitavastatin (FE 2.12 under → FE 0.45 over) was NOT a magnitude improvement; both directions show ~2x absolute fold-error. The actual root cause is OATP1B1 Jmax / ECM passive PS calibration (Hirano 2004 scaled-from-pravastatin estimate carries ~2x literature range), not metabolic_fraction.
+
+### Numbers
+
+| metric | post-v0.3 (Task 5 gating, no auto-ECM) | post-v0.3.1 (auto-ECM activated, mf=0) |
+|---|---|---|
+| pita predict() Cmax (2 mg) | 0.00777 mg/L | 0.00168 mg/L |
+| FE vs FDA Livalo 0.0035 | 2.22x over | 2.08x under |
+
+107-holdout AAFE invariant: pitavastatin is not in the 107-holdout, so Meta 2.679 / Engine 3.791 / ML 3.012 / In-domain Meta 2.733 are unchanged. No cache regen.
+
+### Test impact
+
+- `tests/regression/test_oatp_registry_schema.py`: `_EXPECTED_ECM_APPLICABLE` updated to include pitavastatin; all 3 schema gates green.
+- `tests/integration/test_predict_auto_ecm.py`: `test_pitavastatin_no_auto_ecm` replaced with `test_pitavastatin_auto_ecm_activates` (asserts warning tag present, Cmax matches 0.00168 ± 5%).
+- `tests/integration/test_oatp_ecm_statins.py::test_statin_cmax_under_ecm[pitavastatin]`: unchanged (manual-build path was already ECM-active; FE 2.12 within 3-fold gate).
+- 23 passed / 3 xfailed across the OATP + predict_auto_ecm suite.
+
+### Open follow-ups (deferred)
+
+- Pitavastatin Jmax/PS recalibration: Hirano 2004 scaled-from-pravastatin assumption needs primary verification. ~0.5-1d work, or could be combined with rosuvastatin/atorvastatin promotion (also blocked on Peff over-prediction).
+- DE-33 Vss/Kp engine-layer recalibration: same root-cause class as pita's Jmax/PS uncertainty. Larger scope.
+
+### Closes
+
+- (No issue directly closed; this is a v0.3 follow-up commit.)
+- Expands ECM auto-activation seed list 1 → 2 drugs.
 
 ---
 

--- a/tests/integration/test_predict_auto_ecm.py
+++ b/tests/integration/test_predict_auto_ecm.py
@@ -69,23 +69,33 @@ def test_fluvastatin_no_auto_ecm():
 
 
 @pytest.mark.slow
-def test_pitavastatin_no_auto_ecm():
-    """predict(pitavastatin) does NOT auto-activate ECM (no metabolic_fraction entry).
+def test_pitavastatin_auto_ecm_activates():
+    """predict(pitavastatin) auto-activates ECM under v0.3.1 promotion.
 
-    The schema regression test gates this at registry level; this test gates it
-    at predict() runtime. Two layers of defense.
+    Pitavastatin was promoted to ecm_applicable=true on 2026-05-04 with
+    metabolic_fraction=0 (parallel pravastatin justification: Niemi 2009
+    PM/EM ~3x; OATP1B1 hepatic uptake is rate-limiting).
+
+    EMPIRICAL NOTE: pitavastatin Cmax under auto-ECM is 0.00168 mg/L (FE
+    2.08x under FDA Livalo 0.0035). The under-prediction reflects
+    Jmax/PS calibration uncertainty (Hirano 2004 scaled-from-pravastatin
+    estimate carries ~2x literature range), NOT metabolic_fraction error
+    (sweep mf=[0,1] showed <2% Cmax variation). Mechanistic correctness
+    (OATP-rate-limited path active) is the v0.3.1 gain; absolute Cmax
+    accuracy improvement is deferred to per-drug Jmax/PS curation.
     """
     result = predict(_PITA_SMILES, dose_mg=2.0, route="oral", n_mc_samples=0)
     assert result.engine_pk is not None
     cmax = result.engine_pk.cmax.mean
-    assert not any("oatp1b1:auto_ecm" in w for w in result.warnings), (
-        f"pitavastatin should NOT auto-activate ECM, but got warnings: {result.warnings}"
+    assert any("oatp1b1:auto_ecm:pitavastatin" in w for w in result.warnings), (
+        f"expected oatp1b1:auto_ecm:pitavastatin warning, got: {result.warnings}"
     )
-    expected = 0.00777
+    expected = 0.00168
     rel_err = abs(cmax - expected) / expected
     assert rel_err < 0.05, (
-        f"pitavastatin Cmax drifted: actual={cmax:.5f}, expected={expected:.5f} "
-        f"(no-ECM path post-gating). Gate may be leaking."
+        f"pitavastatin auto-ECM Cmax drift: actual={cmax:.5f}, expected={expected:.5f}, "
+        f"rel_err={rel_err:.3f} (5% tol). Auto-activation may be misfiring "
+        f"or Jmax/PS/mf parameters drifted."
     )
 
 

--- a/tests/regression/test_oatp_registry_schema.py
+++ b/tests/regression/test_oatp_registry_schema.py
@@ -29,7 +29,9 @@ _OVERRIDES_PATH = _REPO_ROOT / "data" / "transporters" / "cyp_clearance_override
 
 # Pin the v0.3 seed list. If a drug is added/removed here, this test
 # must fail loud so the spec change requires an explicit decision.
-_EXPECTED_ECM_APPLICABLE = frozenset({"pravastatin"})
+# 2026-05-04 (v0.3.1): pitavastatin promoted with metabolic_fraction=0
+# (Niemi 2009 PM/EM ~3x, OATP-rate-limited, parallel pravastatin justification).
+_EXPECTED_ECM_APPLICABLE = frozenset({"pravastatin", "pitavastatin"})
 
 
 def _load_oatp() -> dict:


### PR DESCRIPTION
## Summary

v0.3 follow-up. Promotes pitavastatin to `ecm_applicable=true` in `oatp1b1.json`. Pairs with `metabolic_fraction=0` entry in `cyp_clearance_overrides.json` (parallel pravastatin justification: Niemi 2009 PM/EM ~3x → OATP1B1-rate-limited).

Expands v0.3 seed list from 1 → 2 drugs.

## Honest framing

**Empirical sweep on `feat/pitavastatin-ecm-applicable` (2026-05-04)**: pitavastatin Cmax varies from 0.00168 → 0.00165 mg/L across `mf ∈ [0.0, 1.0]` (1.8% relative variation). The triple-counting hypothesis from PR #22 / PR #29 narrative does NOT apply meaningfully here — `mf` is a near-irrelevant knob for pitavastatin.

**This retroactively revises PR #29's pitavastatin narrative**: the pre-v0.3 (buggy auto-ECM) → post-v0.3 (no-ECM) flip (FE 2.12 → 0.45) was direction-only, not magnitude improvement. Both directions show ~2x absolute fold-error.

The actual root cause is OATP1B1 Jmax / ECM passive PS calibration uncertainty (Hirano 2004 `scaled-from-pravastatin` estimate carries ~2x literature range), NOT metabolic_fraction. v0.3.x parameter recalibration tracked separately.

## What changes

| metric | post-v0.3 (no auto-ECM) | post-v0.3.1 (auto-ECM, mf=0) |
|---|---|---|
| pita predict() Cmax (2 mg) | 0.00777 mg/L | 0.00168 mg/L |
| FE vs FDA Livalo 0.0035 | 2.22x over | 2.08x under |
| Direction | over-prediction | under-prediction |
| Mechanism | XGBoost-CYP only (wrong physics) | OATP1B1 + ECM passive + biliary (correct physics) |

The v0.3.1 gain is mechanistic correctness, not absolute Cmax accuracy. The OATP-rate-limited path is now active for pitavastatin (matching its clinical PGx behavior, Niemi 2009 PM/EM ~3x).

## 107-holdout AAFE invariant

Pitavastatin is not in the 107-holdout. Meta 2.679 / Engine 3.791 / ML 3.012 / In-domain Meta 2.733 unchanged. No cache regen needed.

## Files

- `data/transporters/cyp_clearance_overrides.json`: pitavastatin entry added (mf=0, literature Hirano 2004 / Niemi 2009 / Fujino 2004).
- `data/transporters/oatp1b1.json`: pitavastatin `ecm_applicable: true` added.
- `tests/regression/test_oatp_registry_schema.py`: `_EXPECTED_ECM_APPLICABLE = frozenset({"pravastatin", "pitavastatin"})`.
- `tests/integration/test_predict_auto_ecm.py`: `test_pitavastatin_no_auto_ecm` replaced with `test_pitavastatin_auto_ecm_activates` (asserts warning tag + Cmax 0.00168 ± 5%).
- `docs/claude/experiment-log.md`: 2026-05-04 v0.3.1 entry with empirical sweep notes.

## Test plan

- [x] Schema regression test (3 gates) green
- [x] `test_pitavastatin_auto_ecm_activates` asserts new behavior
- [x] `test_oatp_ecm_statins[pitavastatin]` unchanged (manual-build path; FE 2.12 within 3-fold gate)
- [x] OATP suite: 23 pass / 3 xfail (xfails pre-existing rosuva/atorva/fluva Peff)
- [x] 107-holdout cache: not regenerated (pita not in holdout)

## Open follow-ups

- Pitavastatin Jmax/PS recalibration: Hirano 2004 scaled-from-pravastatin assumption needs primary verification. Could be combined with rosuvastatin/atorvastatin promotion (also blocked on Peff over-prediction).
- DE-33 Vss/Kp engine-layer recalibration: same root-cause class as pita's residual ~2x error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)