### PR TITLE
feat(phenotype): phenotype_scale_overrides API hook (v0.3.3, #31)

### DIFF
--- a/docs/claude/experiment-log.md
+++ b/docs/claude/experiment-log.md
@@ -10,6 +10,63 @@ Reverse-chronological. Top-level [CLAUDE.md](../../CLAUDE.md) carries only the *
 
 ---
 
+## 2026-05-07 — v0.3.3 phenotype_scale_overrides API hook
+
+**Branch**: `feat/phenotype-scale-overrides` (PR pending)
+**Spec**: `docs/superpowers/specs/2026-05-07-phenotype-scale-overrides-design.md` (commit `8dd6cf7`)
+**Closes**: issue #31 (capability request from GenoADME — per-substrate effective phenotype scale injection)
+
+### What shipped
+
+`apply_phenotype_to_graph()` and `predict()` now accept a `phenotype_scale_overrides: dict[str, float] | None = None` keyword. When provided AND a gene matches a key in `phenotypes`, the override value replaces `PHENOTYPE_SCALES[phenotype]` for that gene's effect on the matched node's enzyme/transporter abundance. Negative values raise ValueError; no upper bound on positive values (caller responsibility).
+
+Signature shape: flat `{gene: scale}` dict — substrate dimension implicit in per-call SMILES, phenotype dimension implicit in per-call `phenotypes` argument. Mechanically equivalent to GenoADME's originally-proposed 3-level `{gene: {phenotype: {substrate: scale}}}`, simpler. Counter-proposal posted on issue #31 comment, awaiting GenoADME ack but proceeding (signature is small implementation detail).
+
+Sisyphus ships **no calibration tables**. Caller (GenoADME's case) is responsible for resolving `(SMILES, gene, phenotype) → override scale` from their own meta-analysis tables, and passing the resolved scale via `phenotype_scale_overrides` per call.
+
+### Empirical example (pravastatin SLCO1B1)
+
+| call | OATP1B1 abundance scaling | Cmax (mg/L) | PM/EM ratio |
+|---|---|---|---|
+| `phenotypes={"SLCO1B1": "EM"}` | 1.00× | 0.04218 | 1.000 (baseline) |
+| `phenotypes={"SLCO1B1": "PM"}`, no override | 0.10× (CPIC) | 0.12800 | 3.034 |
+| `phenotypes={"SLCO1B1": "PM"}, phenotype_scale_overrides={"SLCO1B1": 0.30}` | 0.30× | 0.07310 | **1.73** (compressed) |
+
+Override compresses toward EM as specified. GenoADME can dial in any scale to match their meta-analysis target (e.g., Niemi 2006 men-stratum AUC ratio 3.32 central).
+
+### 4-task subagent-driven execution
+
+Tasks 1-4 (`291d74f` → `740da17`):
+1. 7 failing unit tests (TDD target — TypeError on unknown kwarg)
+2. `phenotype.py` extension: signature kwarg + override branch in scale-lookup loop + unused-key logger.info — 7/7 + 35/35 existing PASS
+3. `pipeline/predict.py` forward: signature + docstring + apply_phenotype_to_graph forwarding — spot-check ordering EM < Override < Default confirmed
+4. Integration test (pravastatin compression + None/{} backward-compat) — 2/2 PASS, 849 full-suite PASS, Meta 2.679 holdout invariant
+
+### 107-holdout impact
+
+Bit-identical (Meta 2.679 pin holds). Production benchmark uses default `phenotype_scale_overrides=None`. The override only changes behavior when the caller explicitly passes it.
+
+### Architecture invariants preserved
+
+- Engine: 0 line changes (override only changes abundance scaling at apply_phenotype_to_graph time)
+- Distribution-everywhere: scaled Distribution flows downstream identically (Invariant #2)
+- No drug-specific branches in code: substrate-keyed override registry lives in caller, not Sisyphus (Invariant #6)
+- v0.3.2 back-solve cancellation fix preserved — override applies BEFORE the snapshot semantics
+
+### Open follow-ups
+
+- GenoADME applies their meta-analysis-derived overrides and re-computes 1000G PM/EM AUC ratio against Niemi 2006 men-stratum central 3.32 (downstream task, not Sisyphus)
+- Multi-node overrides (gut_wall enzyme phenotype scaling) — not requested, separate concern
+- If GenoADME pushes back on flat signature, revise to 3-level dict (small spec change, not blocking merge)
+
+### How to apply
+
+- "What does v0.3.3 do?" → adds `phenotype_scale_overrides` kwarg to `apply_phenotype_to_graph` and `predict()`. Caller injects per-gene effective scale to override CPIC defaults.
+- "Did headline AAFE change?" → No. 107-holdout invariant. Production `predict()` calls without overrides are unaffected.
+- "Should Sisyphus ship calibration tables?" → No, by design. Caller curates substrate→override mappings. Sisyphus stays opinion-free on substrate-specific empirical claims.
+
+---
+
 ## 2026-05-06 — v0.3.2 NAT2 + UGT1A1 phenotype propagation + back-solve cancellation fix
 
 **Branch**: `feat/nat2-ugt1a1-phenotype` (PR pending)

--- a/docs/superpowers/plans/2026-05-07-phenotype-scale-overrides.md
+++ b/docs/superpowers/plans/2026-05-07-phenotype-scale-overrides.md
@@ -1,0 +1,641 @@
+# Phenotype Scale Overrides (v0.3.3) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `phenotype_scale_overrides: dict[str, float] | None = None` keyword to both `apply_phenotype_to_graph()` and `predict()` so downstream callers (GenoADME) can inject per-substrate-effective phenotype scales without Sisyphus committing to substrate-specific calibration tables.
+
+**Architecture:** Flat `{gene: scale}` dict — substrate dimension implicit in per-call SMILES, phenotype dimension implicit in per-call `phenotypes` argument. Override replaces `PHENOTYPE_SCALES[phenotype]` for matching gene at scaling time. No engine changes. No calibration registry shipped.
+
+**Tech Stack:** Python 3.10+, pytest, existing phenotype/pipeline modules.
+
+**Spec:** `docs/superpowers/specs/2026-05-07-phenotype-scale-overrides-design.md` (commit `8dd6cf7`).
+
+**Branch:** `feat/phenotype-scale-overrides` from `main` (HEAD `8dd6cf7`, post-PR #32 v0.3.2 merge).
+
+---
+
+## Pre-flight: branch setup
+
+- [ ] **Step 0a: Confirm clean main and create feature branch**
+
+```bash
+git status
+git checkout -b feat/phenotype-scale-overrides
+git log --oneline -3
+```
+
+Expected: clean working tree on main; new branch created; HEAD shows `8dd6cf7` (spec) + `1e06ded` (v0.3.2 merge) + earlier.
+
+---
+
+## File Structure
+
+**Create:**
+- `tests/unit/test_phenotype_scale_overrides.py` — 7 unit tests for `apply_phenotype_to_graph` extension
+- `tests/integration/test_phenotype_scale_overrides_pravastatin.py` — end-to-end via `predict()` with empirical pravastatin SLCO1B1:PM compression
+
+**Modify:**
+- `src/sisyphus/predict/phenotype.py` — `apply_phenotype_to_graph` signature + override branch in scale lookup loop
+- `src/sisyphus/pipeline/predict.py` — `predict()` signature + forward kwarg to internal `apply_phenotype_to_graph` call
+- `docs/claude/experiment-log.md` — v0.3.3 entry (closing operation)
+
+**Untouched (verify diff = 0 lines):**
+- `src/sisyphus/engine/*` — engine is identity-blind
+- `data/training/4track_holdout_predictions.json` — holdout invariance
+- All other tests not listed above (must pass unchanged)
+
+---
+
+## Task 1: Failing unit test for phenotype_scale_overrides
+
+**Why first:** TDD. Locks in the expected API + behavior before implementation. Tests should fail because `apply_phenotype_to_graph` doesn't yet accept the new kwarg.
+
+**Files:**
+- Create: `tests/unit/test_phenotype_scale_overrides.py`
+
+- [ ] **Step 1: Write the failing test file**
+
+```python
+"""Unit tests for phenotype_scale_overrides kwarg on apply_phenotype_to_graph (issue #31)."""
+from __future__ import annotations
+
+import logging
+import pathlib
+
+import pytest
+
+from sisyphus.graph.builder import build_from_yaml
+from sisyphus.predict.phenotype import apply_phenotype_to_graph
+
+
+def _fresh_graph():
+    return build_from_yaml(pathlib.Path("data/physiology/reference_man.yaml"))
+
+
+def test_overrides_none_preserves_existing():
+    """phenotype_scale_overrides=None must produce identical output to no kwarg."""
+    g = _fresh_graph()
+    a = apply_phenotype_to_graph(g, {"CYP1A2": "PM"})
+    b = apply_phenotype_to_graph(g, {"CYP1A2": "PM"}, phenotype_scale_overrides=None)
+    assert a.nodes["liver"].enzymes["CYP1A2"].mean == pytest.approx(
+        b.nodes["liver"].enzymes["CYP1A2"].mean
+    )
+
+
+def test_overrides_empty_preserves_existing():
+    g = _fresh_graph()
+    a = apply_phenotype_to_graph(g, {"CYP1A2": "PM"})
+    b = apply_phenotype_to_graph(g, {"CYP1A2": "PM"}, phenotype_scale_overrides={})
+    assert a.nodes["liver"].enzymes["CYP1A2"].mean == pytest.approx(
+        b.nodes["liver"].enzymes["CYP1A2"].mean
+    )
+
+
+def test_override_replaces_default_scale_enzyme():
+    """SLCO1B1:PM with override 0.30 scales OATP1B1 abundance to 30% (vs default 10%)."""
+    g = _fresh_graph()
+    original = g.nodes["liver"].transporters["OATP1B1"].mean
+
+    default_pm = apply_phenotype_to_graph(g, {"SLCO1B1": "PM"})
+    overridden = apply_phenotype_to_graph(
+        g, {"SLCO1B1": "PM"},
+        phenotype_scale_overrides={"SLCO1B1": 0.30},
+    )
+
+    assert default_pm.nodes["liver"].transporters["OATP1B1"].mean == pytest.approx(
+        original * 0.10
+    )
+    assert overridden.nodes["liver"].transporters["OATP1B1"].mean == pytest.approx(
+        original * 0.30
+    )
+
+
+def test_override_replaces_default_scale_cyp():
+    """CYP1A2:PM with override 0.50 scales abundance to 50% (vs default 10%)."""
+    g = _fresh_graph()
+    original = g.nodes["liver"].enzymes["CYP1A2"].mean
+
+    overridden = apply_phenotype_to_graph(
+        g, {"CYP1A2": "PM"},
+        phenotype_scale_overrides={"CYP1A2": 0.50},
+    )
+    assert overridden.nodes["liver"].enzymes["CYP1A2"].mean == pytest.approx(
+        original * 0.50
+    )
+
+
+def test_negative_override_raises():
+    g = _fresh_graph()
+    with pytest.raises(ValueError, match="negative"):
+        apply_phenotype_to_graph(
+            g, {"CYP1A2": "PM"},
+            phenotype_scale_overrides={"CYP1A2": -0.1},
+        )
+
+
+def test_override_for_gene_not_in_phenotypes_logs_info(caplog):
+    """Override key for a gene not in the phenotypes dict is silently ignored."""
+    g = _fresh_graph()
+    caplog.set_level(logging.INFO)
+    out = apply_phenotype_to_graph(
+        g, {"CYP1A2": "PM"},
+        phenotype_scale_overrides={"CYP2C9": 0.20},
+    )
+    # CYP2C9 abundance unchanged (override not applied because CYP2C9 not in phenotypes)
+    assert out.nodes["liver"].enzymes["CYP2C9"].mean == pytest.approx(
+        g.nodes["liver"].enzymes["CYP2C9"].mean
+    )
+    # logger.info note about ignored override
+    info_records = [r for r in caplog.records if r.levelno == logging.INFO and "ignored" in r.getMessage()]
+    assert info_records, "expected logger.info about ignored override key"
+
+
+def test_multiple_genes_overridden_independently():
+    g = _fresh_graph()
+    cyp_orig = g.nodes["liver"].enzymes["CYP1A2"].mean
+    nat2_orig = g.nodes["liver"].enzymes["NAT2"].mean
+
+    out = apply_phenotype_to_graph(
+        g,
+        {"CYP1A2": "PM", "NAT2": "IM"},
+        phenotype_scale_overrides={"CYP1A2": 0.40, "NAT2": 0.65},
+    )
+    assert out.nodes["liver"].enzymes["CYP1A2"].mean == pytest.approx(cyp_orig * 0.40)
+    assert out.nodes["liver"].enzymes["NAT2"].mean == pytest.approx(nat2_orig * 0.65)
+```
+
+- [ ] **Step 2: Run test to verify it fails (kwarg not accepted)**
+
+Run: `pytest tests/unit/test_phenotype_scale_overrides.py -v`
+
+Expected: TypeError on `phenotype_scale_overrides` keyword (function doesn't accept it). All 7 tests FAIL on this signature error.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/unit/test_phenotype_scale_overrides.py
+git commit -m "$(cat <<'EOF'
+test(phenotype): failing tests for phenotype_scale_overrides (TDD target)
+
+7 unit tests locking in the API surface from spec section 4.1:
+- None / {} preserve existing behavior
+- Override replaces PHENOTYPE_SCALES default for matching (gene, phenotype) tuple
+- Works for both transporter (SLCO1B1 -> OATP1B1) and enzyme (CYP1A2) paths
+- Negative value raises ValueError
+- Override key for gene not in phenotypes dict logs info, no scale applied
+- Multiple gene overrides apply independently
+
+Tests fail pre-implementation (signature does not accept new kwarg).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Implement phenotype_scale_overrides in phenotype.py
+
+**Why:** Closes the 7 failing tests from Task 1.
+
+**Files:**
+- Modify: `src/sisyphus/predict/phenotype.py:97-172` (`apply_phenotype_to_graph`)
+
+- [ ] **Step 1: Locate the current function body**
+
+Run: `sed -n '97,172p' src/sisyphus/predict/phenotype.py`
+
+Expected: existing function `apply_phenotype_to_graph(graph, phenotypes, node="liver")` with the for-loop iterating phenotypes and applying `PHENOTYPE_SCALES[phenotype]` scaling.
+
+- [ ] **Step 2: Add `phenotype_scale_overrides` kwarg + override branch**
+
+Open `src/sisyphus/predict/phenotype.py`. Update the function signature to:
+
+```python
+def apply_phenotype_to_graph(
+    graph: BodyGraph,
+    phenotypes: dict[str, str],
+    node: str = "liver",
+    phenotype_scale_overrides: dict[str, float] | None = None,
+) -> BodyGraph:
+```
+
+Update the docstring to add this Args entry (between `node:` and the `Returns:`):
+
+```python
+        phenotype_scale_overrides: Optional ``{gene: effective_scale}`` dict.
+            When provided AND a gene matches a key in ``phenotypes``, the
+            override value replaces ``PHENOTYPE_SCALES[phenotype]`` for that
+            gene's effect on the matched node's enzyme/transporter abundance.
+            Values are caller-supplied and caller-justified — Sisyphus does
+            not endorse specific values. Negative values raise ValueError.
+            Default ``None`` preserves current behavior.
+```
+
+In the body, locate the line `scale = PHENOTYPE_SCALES[phenotype]` (currently around line 132). Replace that line and the immediately-following code with:
+
+```python
+        scale = PHENOTYPE_SCALES[phenotype]
+        if phenotype_scale_overrides is not None and tag in phenotype_scale_overrides:
+            override_scale = phenotype_scale_overrides[tag]
+            if override_scale < 0:
+                raise ValueError(
+                    f"phenotype_scale_overrides[{tag!r}]={override_scale} is negative"
+                )
+            logger.info(
+                "phenotype: override %s default scale %.3f -> %.3f",
+                tag, scale, override_scale,
+            )
+            scale = override_scale
+```
+
+After the `for tag, phenotype in phenotypes.items():` loop closes (and before the `if unknown:` block, currently around line 157), insert:
+
+```python
+    if phenotype_scale_overrides:
+        unused_overrides = sorted(set(phenotype_scale_overrides) - set(phenotypes))
+        if unused_overrides:
+            logger.info(
+                "phenotype: overrides for %s not in phenotypes dict, ignored",
+                unused_overrides,
+            )
+```
+
+- [ ] **Step 3: Run unit tests to verify they pass**
+
+Run: `pytest tests/unit/test_phenotype_scale_overrides.py -v`
+
+Expected: 7 PASS.
+
+- [ ] **Step 4: Run existing phenotype tests for backward compatibility**
+
+Run: `pytest tests/unit/test_phenotype.py tests/unit/test_pipeline_phenotypes.py -v`
+
+Expected: All PASS unchanged.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sisyphus/predict/phenotype.py
+git commit -m "$(cat <<'EOF'
+feat(phenotype): phenotype_scale_overrides kwarg on apply_phenotype_to_graph
+
+Override branch in scale-lookup loop: when a gene tag appears in both
+phenotypes and phenotype_scale_overrides, the override value replaces
+PHENOTYPE_SCALES[phenotype] for that gene's abundance scaling.
+logger.info notes both successful overrides and unused override keys.
+
+Validation: negative values raise ValueError. No upper bound on positive
+values (caller responsibility). Backward-compatible: None / {} preserve
+existing behavior.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Wire phenotype_scale_overrides through predict()
+
+**Why:** Exposes the override at the pipeline-level entry point so callers (e.g., GenoADME) can use `predict()` directly without dropping to graph-layer APIs.
+
+**Files:**
+- Modify: `src/sisyphus/pipeline/predict.py` (signature + forward to apply_phenotype_to_graph)
+
+- [ ] **Step 1: Locate the predict() signature**
+
+Run: `grep -n "^def predict" src/sisyphus/pipeline/predict.py`
+
+Expected: line ~70-80 starting `def predict(...)` with existing kwargs (smiles, dose_mg, route, n_mc_samples, kp_method, phenotypes, infusion_duration_min).
+
+- [ ] **Step 2: Add `phenotype_scale_overrides` kwarg to predict() signature**
+
+Add the new kwarg in the same group as `phenotypes` (visually adjacent — they're a related pair):
+
+```python
+def predict(
+    smiles: str,
+    dose_mg: float = 100.0,
+    route: str = "oral",
+    n_mc_samples: int = 0,
+    kp_method: str | None = None,
+    phenotypes: dict[str, str] | None = None,
+    phenotype_scale_overrides: dict[str, float] | None = None,
+    *,
+    infusion_duration_min: float | None = None,
+) -> PredictionResult:
+```
+
+(If the existing signature uses different formatting/order, preserve that — only insert `phenotype_scale_overrides` immediately after `phenotypes`.)
+
+- [ ] **Step 3: Forward the kwarg to apply_phenotype_to_graph**
+
+Locate the existing `if phenotypes: ... apply_phenotype_to_graph(graph, phenotypes)` block (post-v0.3.2, around line 269-271). Update to:
+
+```python
+        if phenotypes:
+            from sisyphus.predict.phenotype import apply_phenotype_to_graph
+            graph = apply_phenotype_to_graph(
+                graph, phenotypes,
+                phenotype_scale_overrides=phenotype_scale_overrides,
+            )
+```
+
+- [ ] **Step 4: Update predict() docstring**
+
+Find the existing `phenotypes:` docstring entry (around line 105-115). Add an analogous entry immediately after, e.g.:
+
+```python
+        phenotype_scale_overrides: Optional ``{gene: effective_scale}`` dict
+            forwarded to ``apply_phenotype_to_graph``. When provided and a
+            gene matches a key in ``phenotypes``, the override replaces the
+            CPIC default scale for that gene. Values are caller-supplied
+            and caller-justified — Sisyphus does not endorse specific values.
+```
+
+- [ ] **Step 5: Spot-check pipeline integration**
+
+Run:
+
+```bash
+python3 << 'PYEOF'
+from sisyphus.pipeline.predict import predict
+prava = ("CC[C@@H](C)C(=O)O[C@@H]1C[C@H](C=C2[C@@H]1CC[C@H]"
+         "([C@@H]2CC[C@H](C[C@H](CC(=O)O)O)O)C)O")
+
+em = predict(prava, dose_mg=40.0, phenotypes={"SLCO1B1": "EM"})
+default_pm = predict(prava, dose_mg=40.0, phenotypes={"SLCO1B1": "PM"})
+override_pm = predict(
+    prava, dose_mg=40.0,
+    phenotypes={"SLCO1B1": "PM"},
+    phenotype_scale_overrides={"SLCO1B1": 0.30},
+)
+print("EM Cmax:", em.engine_pk.cmax.mean)
+print("Default PM Cmax:", default_pm.engine_pk.cmax.mean)
+print("Override PM (0.30) Cmax:", override_pm.engine_pk.cmax.mean)
+print("Default PM/EM ratio:", default_pm.engine_pk.cmax.mean / em.engine_pk.cmax.mean)
+print("Override PM/EM ratio:", override_pm.engine_pk.cmax.mean / em.engine_pk.cmax.mean)
+print("Override compresses:", em.engine_pk.cmax.mean < override_pm.engine_pk.cmax.mean < default_pm.engine_pk.cmax.mean)
+PYEOF
+```
+
+Expected: Override PM Cmax falls between EM and Default PM (compression toward EM); ordering `EM < Override PM < Default PM`. Override PM/EM ratio is smaller than Default PM/EM ratio.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/sisyphus/pipeline/predict.py
+git commit -m "$(cat <<'EOF'
+feat(pipeline): forward phenotype_scale_overrides through predict()
+
+predict() now accepts phenotype_scale_overrides kwarg adjacent to
+phenotypes. Forwarded verbatim to apply_phenotype_to_graph. Default
+None preserves existing behavior. 107-holdout invariant (production
+benchmark uses default None).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Integration test — pravastatin SLCO1B1 PM/EM compression
+
+**Why:** Empirical end-to-end gate. Confirms the override actually compresses the PM/EM Cmax shift toward EM (the GenoADME use case).
+
+**Files:**
+- Create: `tests/integration/test_phenotype_scale_overrides_pravastatin.py`
+
+- [ ] **Step 1: Write the integration test**
+
+```python
+"""Integration test for phenotype_scale_overrides via predict() — pravastatin SLCO1B1 (#31).
+
+End-to-end gate: override 0.30 (vs CPIC default 0.10) for SLCO1B1:PM
+compresses pravastatin Cmax toward EM. The GenoADME use case is
+calibrating Sisyphus's PM/EM AUC ratio toward Niemi 2006 men-stratum
+central 3.32 (vs current default ~4.5); the equivalent Cmax-side
+ordering test is what we verify here.
+"""
+from __future__ import annotations
+
+import pytest
+
+from sisyphus.pipeline.predict import predict
+
+
+_PRAVASTATIN = (
+    "CC[C@@H](C)C(=O)O[C@@H]1C[C@H](C=C2[C@@H]1CC[C@H]"
+    "([C@@H]2CC[C@H](C[C@H](CC(=O)O)O)O)C)O"
+)
+
+
+@pytest.mark.slow
+def test_pravastatin_slco1b1_pm_override_compresses_toward_em():
+    """SLCO1B1:PM override 0.30 must produce a Cmax between EM and default-PM.
+
+    Compression ordering: EM < Override-PM < Default-PM.
+    Default PM scales OATP1B1 abundance × 0.10 → maximum uptake reduction
+    → highest Cmax. Override 0.30 scales × 0.30 → less uptake reduction
+    → Cmax closer to EM. EM is unchanged baseline.
+    """
+    em = predict(_PRAVASTATIN, dose_mg=40.0, phenotypes={"SLCO1B1": "EM"})
+    default_pm = predict(_PRAVASTATIN, dose_mg=40.0, phenotypes={"SLCO1B1": "PM"})
+    override_pm = predict(
+        _PRAVASTATIN, dose_mg=40.0,
+        phenotypes={"SLCO1B1": "PM"},
+        phenotype_scale_overrides={"SLCO1B1": 0.30},
+    )
+    assert em.engine_pk is not None and default_pm.engine_pk is not None and override_pm.engine_pk is not None
+
+    em_cmax = em.engine_pk.cmax.mean
+    default_pm_cmax = default_pm.engine_pk.cmax.mean
+    override_pm_cmax = override_pm.engine_pk.cmax.mean
+
+    assert em_cmax < override_pm_cmax < default_pm_cmax, (
+        f"compression ordering violated: EM={em_cmax:.4f}, "
+        f"Override-PM={override_pm_cmax:.4f}, Default-PM={default_pm_cmax:.4f}"
+    )
+
+    # Override compresses the PM/EM ratio toward unity
+    default_ratio = default_pm_cmax / em_cmax
+    override_ratio = override_pm_cmax / em_cmax
+    assert 1.0 < override_ratio < default_ratio, (
+        f"override ratio {override_ratio:.3f} not between 1.0 and "
+        f"default {default_ratio:.3f}"
+    )
+
+
+@pytest.mark.slow
+def test_pravastatin_no_override_unchanged():
+    """Calling predict() without phenotype_scale_overrides must produce
+    identical Cmax to omitting the kwarg entirely (backward compat)."""
+    a = predict(_PRAVASTATIN, dose_mg=40.0, phenotypes={"SLCO1B1": "PM"})
+    b = predict(
+        _PRAVASTATIN, dose_mg=40.0, phenotypes={"SLCO1B1": "PM"},
+        phenotype_scale_overrides=None,
+    )
+    c = predict(
+        _PRAVASTATIN, dose_mg=40.0, phenotypes={"SLCO1B1": "PM"},
+        phenotype_scale_overrides={},
+    )
+    assert a.engine_pk.cmax.mean == pytest.approx(b.engine_pk.cmax.mean)
+    assert a.engine_pk.cmax.mean == pytest.approx(c.engine_pk.cmax.mean)
+```
+
+- [ ] **Step 2: Run integration test**
+
+Run: `pytest tests/integration/test_phenotype_scale_overrides_pravastatin.py -v`
+
+Expected: 2 PASS.
+
+- [ ] **Step 3: Run full test suite for regression check**
+
+Run: `pytest tests/unit tests/regression tests/integration -q --no-header 2>&1 | tail -10`
+
+Expected: all PASS or pre-existing xfails only (rosuvastatin / atorvastatin / fluvastatin Peff). No new regressions.
+
+- [ ] **Step 4: Run holdout invariance check**
+
+Run: `pytest tests/integration/test_holdout_regression.py -v`
+
+Expected: PASS (Meta 2.679 pin holds).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/integration/test_phenotype_scale_overrides_pravastatin.py
+git commit -m "$(cat <<'EOF'
+test(integration): pravastatin SLCO1B1:PM override compression (issue #31)
+
+End-to-end gate via predict(): override 0.30 (vs CPIC default 0.10) for
+SLCO1B1:PM compresses pravastatin Cmax toward EM. Ordering:
+EM < Override-PM < Default-PM, override PM/EM ratio < default PM/EM ratio.
+
+Plus backward-compat gate: None / {} produce identical Cmax to no kwarg.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Closing operations
+
+- [ ] **Add experiment-log entry**
+
+Open `docs/claude/experiment-log.md` and prepend (above the most-recent v0.3.2 entry):
+
+```markdown
+## 2026-05-07 — v0.3.3 phenotype_scale_overrides API hook
+
+**Branch**: `feat/phenotype-scale-overrides` (PR pending)
+**Spec**: `docs/superpowers/specs/2026-05-07-phenotype-scale-overrides-design.md` (commit `8dd6cf7`)
+**Closes**: issue #31 (capability request from GenoADME — per-substrate effective phenotype scale injection)
+
+### What shipped
+
+`apply_phenotype_to_graph()` and `predict()` now accept a `phenotype_scale_overrides: dict[str, float] | None = None` keyword. When provided AND a gene matches a key in `phenotypes`, the override value replaces `PHENOTYPE_SCALES[phenotype]` for that gene's effect on the matched node's enzyme/transporter abundance. Negative values raise ValueError; no upper bound on positive values (caller responsibility).
+
+Signature shape: flat `{gene: scale}` dict — substrate dimension implicit in per-call SMILES, phenotype dimension implicit in per-call `phenotypes` argument. Mechanically equivalent to GenoADME's originally-proposed 3-level `{gene: {phenotype: {substrate: scale}}}`, simpler.
+
+Sisyphus ships **no calibration tables**. Caller (GenoADME's case) is responsible for resolving `(SMILES, gene, phenotype) → override scale` from their own meta-analysis tables, and passing the resolved scale via `phenotype_scale_overrides` per call.
+
+### Empirical example (pravastatin)
+
+| call | OATP1B1 abundance scaling | Cmax shift vs EM |
+|---|---|---|
+| `phenotypes={"SLCO1B1": "EM"}` | 1.00× | 1.0× (baseline) |
+| `phenotypes={"SLCO1B1": "PM"}`, no override | 0.10× (CPIC) | ~3.0× |
+| `phenotypes={"SLCO1B1": "PM"}, phenotype_scale_overrides={"SLCO1B1": 0.30}` | 0.30× | < 3.0× (compressed toward EM) |
+
+### 107-holdout impact
+
+Bit-identical (Meta 2.679 pin holds). Production benchmark uses default `phenotype_scale_overrides=None`.
+
+### Open follow-ups
+
+- GenoADME applies their meta-analysis-derived overrides and re-computes 1000G PM/EM AUC ratio against Niemi 2006 men-stratum central 3.32. Out of scope for Sisyphus.
+- Multi-node overrides (gut_wall enzyme phenotype scaling) — not requested, separate concern.
+```
+
+- [ ] **Commit experiment-log update + push branch**
+
+```bash
+git add docs/claude/experiment-log.md
+git commit -m "$(cat <<'EOF'
+docs(experiment-log): v0.3.3 phenotype_scale_overrides entry
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+
+git push -u origin feat/phenotype-scale-overrides
+```
+
+- [ ] **Create PR**
+
+```bash
+gh pr create --title "feat(phenotype): phenotype_scale_overrides API hook (v0.3.3, #31)" --body "$(cat <<'EOF'
+## Summary
+- Closes #31 — capability request from GenoADME (per-substrate effective phenotype scale injection)
+- Adds `phenotype_scale_overrides: dict[str, float] | None` kwarg to `apply_phenotype_to_graph()` and `predict()`
+- Flat `{gene: scale}` signature (simplified from GenoADME's 3-level proposal — substrate dimension implicit in per-call SMILES; phenotype dimension implicit in per-call phenotypes argument)
+- No calibration tables shipped — caller (GenoADME) resolves substrate→override mapping in their own meta-analysis layer
+
+## Empirical (pravastatin SLCO1B1:PM)
+
+| call | OATP1B1 abundance scaling | Cmax compression vs EM |
+|---|---|---|
+| no phenotype | 1.00× | 1.0× |
+| PM, no override | 0.10× (CPIC default) | ~3.0× |
+| PM, override 0.30 | 0.30× | between EM and default PM |
+
+Override compresses PM/EM Cmax shift toward EM, as required by the GenoADME use case (Niemi 2006 men-stratum target ~3.32 central).
+
+## Test plan
+- [x] `pytest tests/unit/test_phenotype_scale_overrides.py -v` — 7 PASS
+- [x] `pytest tests/integration/test_phenotype_scale_overrides_pravastatin.py -v` — 2 PASS
+- [x] `pytest tests/unit/test_phenotype.py tests/unit/test_pipeline_phenotypes.py -v` — all PASS (backward compat)
+- [x] `pytest tests/integration/test_holdout_regression.py -v` — Meta 2.679 invariant
+- [x] CI green
+
+## Architecture
+- Engine: 0 line changes
+- 107-holdout AAFE bit-identical
+- v0.3.2 phenotype back-solve fix (PR #32) preserved — override applies BEFORE the snapshot semantics
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage**
+- §3 architecture (override location, substrate caller-resolved): Tasks 2, 3 implement
+- §4.1 apply_phenotype_to_graph signature: Task 2
+- §4.2 predict signature: Task 3
+- §5.1 phenotype.py loop: Task 2 (override branch + unused-keys logger.info)
+- §5.2 pipeline forwarding: Task 3
+- §6.1 unit tests: Task 1 (7 cases match §6.1 list)
+- §6.2 integration test: Task 4
+- §6.3 backward compat: closing operations + Tasks 2/3 verify existing tests stay green
+- §10 acceptance criteria: covered by Tasks 1-4 + closing holdout check
+
+No gaps.
+
+**2. Placeholder scan**
+All steps include explicit code blocks. No "TBD/TODO" leftovers.
+
+**3. Type consistency**
+- `dict[str, float] | None` consistent across `apply_phenotype_to_graph`, `predict`, and tests
+- `phenotype_scale_overrides` parameter name identical in both functions and signature
+- Tests use the canonical name everywhere
+
+No issues. Ready for execution.

--- a/docs/superpowers/specs/2026-05-07-phenotype-scale-overrides-design.md
+++ b/docs/superpowers/specs/2026-05-07-phenotype-scale-overrides-design.md
@@ -1,0 +1,254 @@
+# Phenotype Scale Overrides (v0.3.3) — Design
+
+**Date**: 2026-05-07
+**Issue**: [#31](https://github.com/jam-sudo/Sisyphus/issues/31) (capability request from GenoADME)
+**Target version**: v0.3.3
+**Branch**: `feat/phenotype-scale-overrides`
+**Predecessor**: PR #32 (v0.3.2 NAT2/UGT1A1 + back-solve cancellation fix, merged `1e06ded`)
+
+---
+
+## 1. Goal
+
+Add a `phenotype_scale_overrides: dict[str, float] | None = None` keyword to both `apply_phenotype_to_graph()` and `predict()`. When provided, the override replaces the default `PHENOTYPE_SCALES[phenotype]` for the matching gene at scaling time. When omitted or `{}`, behavior is identical to current.
+
+The dimension shape is **flat `{gene: scale}`**. Substrate dimension is implicit in the SMILES being passed to `predict()` per call. Phenotype dimension is implicit in the `phenotypes` argument of the same call.
+
+This unblocks GenoADME v0.3 milestone (Niemi 2006 men-stratum AUC PM/EM 3.32 [1.74, 4.91]; current Sisyphus pin yields 4.482 — at the upper edge of CI). GenoADME wants to compress toward the central 3.32 via per-substrate calibration on their side; Sisyphus provides only the API hook with no built-in calibration tables.
+
+## 2. Background
+
+### 2.1 What's in main today (post-v0.3.2)
+
+`src/sisyphus/predict/phenotype.py:97-172` `apply_phenotype_to_graph(graph, phenotypes, node="liver")`:
+- Iterates `phenotypes` dict
+- Looks up `scale = PHENOTYPE_SCALES[phenotype]` (PM=0.10, IM=0.50, EM=1.00, RM=1.50, UM=2.00)
+- For transporter genes (`SLCO1B1` → `OATP1B1`), scales `liver.transporters[OATP1B1].mean`
+- For enzyme genes (`CYP1A2`, `NAT2`, `UGT1A1`, etc.), scales `liver.enzymes[tag].mean`
+- Returns new BodyGraph with scaled Distribution
+
+`src/sisyphus/pipeline/predict.py` calls `apply_phenotype_to_graph` with `phenotypes` argument when provided. v0.3.2 added pre-phenotype enzyme abundance snapshot to make CYP/UGT/NAT propagation work correctly.
+
+### 2.2 Why issue #31
+
+GenoADME's v0.3 meta-analysis extracted SLCO1B1/pravastatin PM/EM AUC ratio data: Niemi 2006 men-stratum 3.32 [1.74, 4.91]. Sisyphus current pin (post-#32) produces 4.482 AUC ratio — inside the CI but at the upper edge. CPIC's 0.10× PM scale is community-standard but compounds non-linearly through the graph layer for some substrates.
+
+GenoADME wants to inject a per-substrate effective scale (e.g., 0.30 for pravastatin) without committing Sisyphus to substrate-specific calibration tables. This issue is downstream-side empirical, not a Sisyphus calibration question — Sisyphus's CPIC-default 0.10 is correct for the community-standard scale; GenoADME has richer empirical data for specific substrates.
+
+## 3. Architecture
+
+**Engine: zero changes.** Override only changes the abundance scale at `apply_phenotype_to_graph` time. The scaled abundance flows through the rest of the pipeline (v0.3.2 back-solve fix included) identically to a default-scale call.
+
+```
+predict(SMILES, phenotypes={"SLCO1B1": "PM"}, phenotype_scale_overrides={"SLCO1B1": 0.30})
+  │
+  ▼
+graph = build_from_yaml(reference_man.yaml)
+liver_enzymes_pre = snapshot (pre-phenotype, per v0.3.2)
+  │
+  ▼
+graph = apply_phenotype_to_graph(graph, phenotypes={"SLCO1B1": "PM"},
+                                  phenotype_scale_overrides={"SLCO1B1": 0.30})
+  → for tag="SLCO1B1": scale = PHENOTYPE_SCALES["PM"] = 0.10
+  → override hit: scale = 0.30
+  → liver.transporters["OATP1B1"].mean *= 0.30   (vs default ×0.10)
+  │
+  ▼
+build_drug_on_graph(..., liver_enzymes=liver_enzymes_pre)
+engine: rate_OATP1B1 = scaled_abundance × Vmax_kinetics  ← MM path, propagates
+```
+
+**Substrate dimension is caller-resolved.** GenoADME's batch pipeline:
+1. Looks up SMILES → drug name (or InChIKey → drug name) in their meta-analysis table
+2. Selects the appropriate override scale per (gene, drug) tuple
+3. Passes resolved `{gene: scale}` to `predict()`
+
+Sisyphus does not maintain a substrate-keyed override registry — that responsibility lives in the caller's curation layer (GenoADME's case: their PGx meta-analysis tables).
+
+## 4. API
+
+### 4.1 `apply_phenotype_to_graph` extension
+
+```python
+def apply_phenotype_to_graph(
+    graph: BodyGraph,
+    phenotypes: dict[str, str],
+    node: str = "liver",
+    phenotype_scale_overrides: dict[str, float] | None = None,
+) -> BodyGraph:
+    """Return a new BodyGraph with enzyme/transporter abundances scaled.
+
+    Args:
+        graph: Input body graph (unchanged).
+        phenotypes: {tag: phenotype_code} from parse_phenotype_spec.
+        node: Which node to scale. Default "liver".
+        phenotype_scale_overrides: Optional {gene: effective_scale}.
+            When provided AND a gene matches a key in phenotypes, the
+            override value replaces PHENOTYPE_SCALES[phenotype] for
+            that gene's effect on the matched node's enzyme/transporter
+            abundance. Values are caller-supplied and caller-justified —
+            Sisyphus does not endorse specific values. Negative values
+            raise ValueError. Default None preserves current behavior.
+
+    Returns: New BodyGraph with scaled Distribution for matched
+        enzymes/transporters.
+    """
+```
+
+Validation:
+- Negative override values → `ValueError` (mathematically meaningless: a negative abundance multiplier).
+- Override key not in `phenotypes` dict → silent no-op + `logger.info("phenotype: override key %s not in phenotypes dict, ignored", tag)`.
+- Override key in `phenotypes` but tag not in graph → existing "tag not found" warning surfaces (override has no effect because there's nothing to scale).
+- No upper bound on positive scale values — caller responsibility.
+
+### 4.2 `predict()` extension
+
+```python
+def predict(
+    smiles: str,
+    dose_mg: float = 100.0,
+    route: str = "oral",
+    n_mc_samples: int = 0,
+    kp_method: str | None = None,
+    phenotypes: dict[str, str] | None = None,
+    phenotype_scale_overrides: dict[str, float] | None = None,
+    *,
+    infusion_duration_min: float | None = None,
+) -> PredictionResult:
+```
+
+`predict()` forwards `phenotype_scale_overrides` verbatim to its internal `apply_phenotype_to_graph` call. No other change.
+
+## 5. Implementation
+
+### 5.1 `src/sisyphus/predict/phenotype.py`
+
+In the `for tag, phenotype in phenotypes.items()` loop (around line 131), after `scale = PHENOTYPE_SCALES[phenotype]`:
+
+```python
+        scale = PHENOTYPE_SCALES[phenotype]
+        if phenotype_scale_overrides is not None and tag in phenotype_scale_overrides:
+            override_scale = phenotype_scale_overrides[tag]
+            if override_scale < 0:
+                raise ValueError(
+                    f"phenotype_scale_overrides[{tag!r}]={override_scale} is negative"
+                )
+            logger.info(
+                "phenotype: override %s default scale %.3f -> %.3f",
+                tag, scale, override_scale,
+            )
+            scale = override_scale
+```
+
+After the loop, log any override keys that were not in `phenotypes`:
+```python
+if phenotype_scale_overrides:
+    unused_overrides = set(phenotype_scale_overrides) - set(phenotypes)
+    if unused_overrides:
+        logger.info("phenotype: overrides for %s not in phenotypes dict, ignored", sorted(unused_overrides))
+```
+
+### 5.2 `src/sisyphus/pipeline/predict.py`
+
+Add `phenotype_scale_overrides: dict[str, float] | None = None` to the `predict()` signature. In the existing `if phenotypes: graph = apply_phenotype_to_graph(graph, phenotypes)` block (post-v0.3.2 around line 269-271), forward the kwarg:
+
+```python
+        if phenotypes:
+            from sisyphus.predict.phenotype import apply_phenotype_to_graph
+            graph = apply_phenotype_to_graph(
+                graph, phenotypes,
+                phenotype_scale_overrides=phenotype_scale_overrides,
+            )
+```
+
+## 6. Tests
+
+### 6.1 Unit (`tests/unit/test_phenotype_scale_overrides.py`, NEW)
+
+- `apply_phenotype_to_graph` with `phenotype_scale_overrides=None` → identical to no kwarg
+- `apply_phenotype_to_graph` with `phenotype_scale_overrides={}` → identical to no kwarg
+- `apply_phenotype_to_graph` with `{"SLCO1B1": 0.30}` → liver.transporters["OATP1B1"].mean reduced to 30% (vs 10% default for PM)
+- `apply_phenotype_to_graph` with `{"CYP1A2": 0.50}` + phenotypes `{"CYP1A2": "PM"}` → liver.enzymes["CYP1A2"].mean × 0.50 (vs default 0.10)
+- Negative override raises ValueError
+- Override key for gene not in phenotypes → no-op + logger.info captured
+- Multiple genes overridden simultaneously work independently
+
+### 6.2 Integration (`tests/integration/test_phenotype_scale_overrides_pravastatin.py`, NEW)
+
+End-to-end via `predict()`:
+- `predict(pravastatin_smiles, phenotypes={"SLCO1B1": "PM"}).cmax_pm` (default 0.10)
+- `predict(pravastatin_smiles, phenotypes={"SLCO1B1": "PM"}, phenotype_scale_overrides={"SLCO1B1": 0.30}).cmax_pm_override` (override 0.30)
+- Default PM Cmax > Override PM Cmax (override is closer to EM, less compression of OATP1B1, lower Cmax shift)
+- The ratio of (PM/EM Cmax) is smaller under override than under default (compresses toward EM)
+- `predict(non_pravastatin)` with the SAME override but different SMILES is identical to the no-override call (override only applies when the gene is in `phenotypes`, which is a per-call argument — but if `phenotypes={"SLCO1B1": "PM"}` is also passed for non-pravastatin, the override applies to that gene's abundance scaling regardless of substrate; the substrate dimension is the SMILES being predicted, which determines whether the drug actually USES the OATP1B1 transporter path)
+
+(The third bullet documents an important subtlety: the override applies at graph-level, so it scales abundance regardless of which drug is being predicted. The substrate-scoping is implicit — if the SMILES doesn't use OATP1B1, scaling OATP1B1 abundance has no effect on its Cmax. Caller should not pass overrides for genes their SMILES doesn't actually depend on.)
+
+### 6.3 Backward compatibility
+
+- `tests/unit/test_phenotype.py` (existing) — must pass unchanged
+- `tests/unit/test_pipeline_phenotypes.py` (existing) — must pass unchanged
+- `tests/integration/test_phenotype_nat2.py`, `test_phenotype_ugt1a1.py`, `test_phenotype_cyp_propagation.py` (v0.3.2) — must pass unchanged
+- `tests/integration/test_holdout_regression.py` — Meta 2.679 pin holds (production `predict()` does not pass `phenotype_scale_overrides`)
+
+## 7. Failure modes
+
+### 7.1 Override applied to gene not in graph
+Existing `apply_phenotype_to_graph` already warns "tag not found" when the gene is not in `liver.enzymes` or `liver.transporters`. Override is a no-op in this case (nothing to scale). Same warning surfaces. No new failure mode.
+
+### 7.2 Override conflicts with `phenotypes` mapping
+If user passes `phenotypes={"SLCO1B1": "PM"}` and `phenotype_scale_overrides={"SLCO1B1": 0.30}`, the override replaces the PM scale. This is the intended semantic. Documented in the docstring.
+
+### 7.3 Caller passes substrate-irrelevant override
+e.g., `predict(metoprolol_smiles, phenotypes={"SLCO1B1": "PM"}, phenotype_scale_overrides={"SLCO1B1": 0.30})`. Metoprolol doesn't use OATP1B1. The override scales liver.transporters["OATP1B1"].mean × 0.30, but metoprolol's flux through OATP1B1 is zero (no transporter_kinetics for metoprolol), so Cmax is unaffected. Silent zero, identical to default-PM behavior for metoprolol. **No bug** — caller-supplied overrides for irrelevant genes are silently no-op via the engine's identity-blind invariant.
+
+### 7.4 Caller-provided values are wrong
+Sisyphus doesn't validate against literature. Caller's responsibility. Documented in docstring: "values are caller-supplied and caller-justified — Sisyphus does not endorse specific values."
+
+## 8. Scope
+
+### In scope (v0.3.3)
+
+- Add `phenotype_scale_overrides` kwarg to `apply_phenotype_to_graph` and `predict()`
+- Override branch in scale lookup loop with logger.info
+- Negative-value ValueError
+- Unit tests (7+ cases) + integration test (pravastatin empirical)
+- v0.3.3 / `feat/phenotype-scale-overrides` branch + PR
+
+### Out of scope
+
+- Sisyphus-shipped substrate-specific calibration tables — caller-side only
+- 3-level dict `{gene: {phenotype: {substrate: scale}}}` — substrate dimension implicit in per-call SMILES, phenotype implicit in per-call `phenotypes` argument; flat `{gene: scale}` is mechanically equivalent
+- Override of `apply_phenotype_to_graph`'s `node` argument — only `liver` is supported in current architecture
+- Multi-node overrides (gut_wall enzyme phenotype scaling) — separate concern, not requested
+
+## 9. Estimated breakdown (4 tasks)
+
+1. Failing test (`tests/unit/test_phenotype_scale_overrides.py`): Override changes the scaled abundance for a matching gene; test currently fails because kwarg not accepted.
+2. `phenotype.py` extension: Add kwarg + override branch + logger.info. Test passes.
+3. `pipeline/predict.py` extension: Forward kwarg through. Add explicit `phenotype_scale_overrides` parameter to `predict()` signature.
+4. Integration test (`tests/integration/test_phenotype_scale_overrides_pravastatin.py`): pravastatin SLCO1B1:PM with override 0.30 produces compressed Cmax shift vs default 0.10.
+
+## 10. Acceptance criteria
+
+- [ ] `apply_phenotype_to_graph(graph, phenotypes={"SLCO1B1": "PM"}, phenotype_scale_overrides={"SLCO1B1": 0.30})` scales liver.transporters["OATP1B1"].mean to 30% of original (not 10%)
+- [ ] `predict(SMILES, phenotypes={"SLCO1B1": "PM"}, phenotype_scale_overrides={"SLCO1B1": 0.30})` produces a Cmax that's between EM and default-PM (override compresses toward EM)
+- [ ] Negative override raises ValueError
+- [ ] All existing phenotype tests pass unchanged
+- [ ] 107-holdout AAFE 2.679 pin holds
+- [ ] CI green
+
+## 11. References
+
+- Issue [#31](https://github.com/jam-sudo/Sisyphus/issues/31)
+- PR #32 (`1e06ded`) — v0.3.2 NAT2 + UGT1A1 + back-solve cancellation fix (predecessor; phenotype propagation infrastructure)
+- GenoADME v0.3 meta-analysis: Niemi 2006 men-stratum SLCO1B1/pravastatin PM/EM AUC ratio 3.32 [1.74, 4.91]
+- CLAUDE.md Invariants 1, 6 (engine identity-blind, no drug-specific branches in code — registry of overrides lives in caller, not Sisyphus)
+
+## 12. Self-review
+
+- ✅ Placeholder scan: 0
+- ✅ Internal consistency: data + code + tests align
+- ✅ Scope check: single API surface change (~50-100 lines), 4 tasks
+- ✅ Ambiguity: override semantic (gene-keyed flat dict; substrate implicit in SMILES; phenotype implicit in phenotypes dict) explicitly documented in §3 and §4.1
+- ✅ Backward compatibility: documented in §6.3 with named test files

--- a/src/sisyphus/pipeline/predict.py
+++ b/src/sisyphus/pipeline/predict.py
@@ -78,6 +78,7 @@ def predict(
     infusion_duration_min: float | None = None,
     *,
     phenotypes: dict[str, str] | None = None,
+    phenotype_scale_overrides: dict[str, float] | None = None,
     kp_method: str = "rodgers_rowland",
 ) -> PredictionResult:
     """End-to-end prediction: SMILES -> PredictionResult.
@@ -114,6 +115,11 @@ def predict(
             phenotype-conditional. ``None`` (default) is the
             average-patient prediction. See
             ``sisyphus.predict.phenotype.PHENOTYPE_SCALES``.
+        phenotype_scale_overrides: Optional ``{gene: effective_scale}`` dict
+            forwarded to ``apply_phenotype_to_graph``. When provided and a
+            gene matches a key in ``phenotypes``, the override replaces the
+            CPIC default scale for that gene. Values are caller-supplied
+            and caller-justified — Sisyphus does not endorse specific values.
         kp_method: Tissue partition coefficient (Kp) calculation method.
             One of ``"rodgers_rowland"`` (default, suitable for most
             small-molecule drugs), ``"berezhkovskiy"`` (alternative
@@ -274,7 +280,10 @@ def predict(
         # liver_enzymes_pre) carries the unscaled baseline.
         if phenotypes:
             from sisyphus.predict.phenotype import apply_phenotype_to_graph
-            graph = apply_phenotype_to_graph(graph, phenotypes)
+            graph = apply_phenotype_to_graph(
+                graph, phenotypes,
+                phenotype_scale_overrides=phenotype_scale_overrides,
+            )
 
         # Rebuild drug with PRE-phenotype abundances. Phenotype's effect on
         # the graph remains (scaled abundances flow into engine multiplication);

--- a/src/sisyphus/predict/phenotype.py
+++ b/src/sisyphus/predict/phenotype.py
@@ -98,6 +98,7 @@ def apply_phenotype_to_graph(
     graph: BodyGraph,
     phenotypes: dict[str, str],
     node: str = "liver",
+    phenotype_scale_overrides: dict[str, float] | None = None,
 ) -> BodyGraph:
     """Return a new BodyGraph with enzyme/transporter abundances scaled.
 
@@ -108,6 +109,13 @@ def apply_phenotype_to_graph(
             (``SLCO1B1``, aliased to graph transporter ``OATP1B1``).
         node: Which node to scale. Default "liver". Enzymes and
             transporters are both sourced from ``graph.nodes[node]``.
+        phenotype_scale_overrides: Optional ``{gene: effective_scale}`` dict.
+            When provided AND a gene matches a key in ``phenotypes``, the
+            override value replaces ``PHENOTYPE_SCALES[phenotype]`` for that
+            gene's effect on the matched node's enzyme/transporter abundance.
+            Values are caller-supplied and caller-justified — Sisyphus does
+            not endorse specific values. Negative values raise ValueError.
+            Default ``None`` preserves current behavior.
 
     Returns:
         New BodyGraph with scaled Distribution for matched enzymes /
@@ -130,6 +138,17 @@ def apply_phenotype_to_graph(
 
     for tag, phenotype in phenotypes.items():
         scale = PHENOTYPE_SCALES[phenotype]
+        if phenotype_scale_overrides is not None and tag in phenotype_scale_overrides:
+            override_scale = phenotype_scale_overrides[tag]
+            if override_scale < 0:
+                raise ValueError(
+                    f"phenotype_scale_overrides[{tag!r}]={override_scale} is negative"
+                )
+            logger.info(
+                "phenotype: override %s default scale %.3f -> %.3f",
+                tag, scale, override_scale,
+            )
+            scale = override_scale
         transporter_tag = TRANSPORTER_ALIASES.get(tag)
         if transporter_tag is not None:
             if transporter_tag not in target_transporters:
@@ -153,6 +172,14 @@ def apply_phenotype_to_graph(
                 dist_type=old.dist_type,
             )
             applied.append(f"{tag}:{phenotype}({scale}×)")
+
+    if phenotype_scale_overrides:
+        unused_overrides = sorted(set(phenotype_scale_overrides) - set(phenotypes))
+        if unused_overrides:
+            logger.info(
+                "phenotype: overrides for %s not in phenotypes dict, ignored",
+                unused_overrides,
+            )
 
     if unknown:
         available = sorted(list(target_enzymes) + [f"(transporter){t}" for t in target_transporters])

--- a/tests/integration/test_phenotype_scale_overrides_pravastatin.py
+++ b/tests/integration/test_phenotype_scale_overrides_pravastatin.py
@@ -1,0 +1,72 @@
+"""Integration test for phenotype_scale_overrides via predict() — pravastatin SLCO1B1 (#31).
+
+End-to-end gate: override 0.30 (vs CPIC default 0.10) for SLCO1B1:PM
+compresses pravastatin Cmax toward EM. The GenoADME use case is
+calibrating Sisyphus's PM/EM AUC ratio toward Niemi 2006 men-stratum
+central 3.32 (vs current default ~4.5); the equivalent Cmax-side
+ordering test is what we verify here.
+"""
+from __future__ import annotations
+
+import pytest
+
+from sisyphus.pipeline.predict import predict
+
+
+_PRAVASTATIN = (
+    "CC[C@@H](C)C(=O)O[C@@H]1C[C@H](C=C2[C@@H]1CC[C@H]"
+    "([C@@H]2CC[C@H](C[C@H](CC(=O)O)O)O)C)O"
+)
+
+
+@pytest.mark.slow
+def test_pravastatin_slco1b1_pm_override_compresses_toward_em():
+    """SLCO1B1:PM override 0.30 must produce a Cmax between EM and default-PM.
+
+    Compression ordering: EM < Override-PM < Default-PM.
+    Default PM scales OATP1B1 abundance × 0.10 → maximum uptake reduction
+    → highest Cmax. Override 0.30 scales × 0.30 → less uptake reduction
+    → Cmax closer to EM. EM is unchanged baseline.
+    """
+    em = predict(_PRAVASTATIN, dose_mg=40.0, phenotypes={"SLCO1B1": "EM"})
+    default_pm = predict(_PRAVASTATIN, dose_mg=40.0, phenotypes={"SLCO1B1": "PM"})
+    override_pm = predict(
+        _PRAVASTATIN, dose_mg=40.0,
+        phenotypes={"SLCO1B1": "PM"},
+        phenotype_scale_overrides={"SLCO1B1": 0.30},
+    )
+    assert em.engine_pk is not None and default_pm.engine_pk is not None and override_pm.engine_pk is not None
+
+    em_cmax = em.engine_pk.cmax.mean
+    default_pm_cmax = default_pm.engine_pk.cmax.mean
+    override_pm_cmax = override_pm.engine_pk.cmax.mean
+
+    assert em_cmax < override_pm_cmax < default_pm_cmax, (
+        f"compression ordering violated: EM={em_cmax:.4f}, "
+        f"Override-PM={override_pm_cmax:.4f}, Default-PM={default_pm_cmax:.4f}"
+    )
+
+    # Override compresses the PM/EM ratio toward unity
+    default_ratio = default_pm_cmax / em_cmax
+    override_ratio = override_pm_cmax / em_cmax
+    assert 1.0 < override_ratio < default_ratio, (
+        f"override ratio {override_ratio:.3f} not between 1.0 and "
+        f"default {default_ratio:.3f}"
+    )
+
+
+@pytest.mark.slow
+def test_pravastatin_no_override_unchanged():
+    """Calling predict() without phenotype_scale_overrides must produce
+    identical Cmax to omitting the kwarg entirely (backward compat)."""
+    a = predict(_PRAVASTATIN, dose_mg=40.0, phenotypes={"SLCO1B1": "PM"})
+    b = predict(
+        _PRAVASTATIN, dose_mg=40.0, phenotypes={"SLCO1B1": "PM"},
+        phenotype_scale_overrides=None,
+    )
+    c = predict(
+        _PRAVASTATIN, dose_mg=40.0, phenotypes={"SLCO1B1": "PM"},
+        phenotype_scale_overrides={},
+    )
+    assert a.engine_pk.cmax.mean == pytest.approx(b.engine_pk.cmax.mean)
+    assert a.engine_pk.cmax.mean == pytest.approx(c.engine_pk.cmax.mean)

--- a/tests/unit/test_phenotype_scale_overrides.py
+++ b/tests/unit/test_phenotype_scale_overrides.py
@@ -1,0 +1,106 @@
+"""Unit tests for phenotype_scale_overrides kwarg on apply_phenotype_to_graph (issue #31)."""
+from __future__ import annotations
+
+import logging
+import pathlib
+
+import pytest
+
+from sisyphus.graph.builder import build_from_yaml
+from sisyphus.predict.phenotype import apply_phenotype_to_graph
+
+
+def _fresh_graph():
+    return build_from_yaml(pathlib.Path("data/physiology/reference_man.yaml"))
+
+
+def test_overrides_none_preserves_existing():
+    """phenotype_scale_overrides=None must produce identical output to no kwarg."""
+    g = _fresh_graph()
+    a = apply_phenotype_to_graph(g, {"CYP1A2": "PM"})
+    b = apply_phenotype_to_graph(g, {"CYP1A2": "PM"}, phenotype_scale_overrides=None)
+    assert a.nodes["liver"].enzymes["CYP1A2"].mean == pytest.approx(
+        b.nodes["liver"].enzymes["CYP1A2"].mean
+    )
+
+
+def test_overrides_empty_preserves_existing():
+    g = _fresh_graph()
+    a = apply_phenotype_to_graph(g, {"CYP1A2": "PM"})
+    b = apply_phenotype_to_graph(g, {"CYP1A2": "PM"}, phenotype_scale_overrides={})
+    assert a.nodes["liver"].enzymes["CYP1A2"].mean == pytest.approx(
+        b.nodes["liver"].enzymes["CYP1A2"].mean
+    )
+
+
+def test_override_replaces_default_scale_enzyme():
+    """SLCO1B1:PM with override 0.30 scales OATP1B1 abundance to 30% (vs default 10%)."""
+    g = _fresh_graph()
+    original = g.nodes["liver"].transporters["OATP1B1"].mean
+
+    default_pm = apply_phenotype_to_graph(g, {"SLCO1B1": "PM"})
+    overridden = apply_phenotype_to_graph(
+        g, {"SLCO1B1": "PM"},
+        phenotype_scale_overrides={"SLCO1B1": 0.30},
+    )
+
+    assert default_pm.nodes["liver"].transporters["OATP1B1"].mean == pytest.approx(
+        original * 0.10
+    )
+    assert overridden.nodes["liver"].transporters["OATP1B1"].mean == pytest.approx(
+        original * 0.30
+    )
+
+
+def test_override_replaces_default_scale_cyp():
+    """CYP1A2:PM with override 0.50 scales abundance to 50% (vs default 10%)."""
+    g = _fresh_graph()
+    original = g.nodes["liver"].enzymes["CYP1A2"].mean
+
+    overridden = apply_phenotype_to_graph(
+        g, {"CYP1A2": "PM"},
+        phenotype_scale_overrides={"CYP1A2": 0.50},
+    )
+    assert overridden.nodes["liver"].enzymes["CYP1A2"].mean == pytest.approx(
+        original * 0.50
+    )
+
+
+def test_negative_override_raises():
+    g = _fresh_graph()
+    with pytest.raises(ValueError, match="negative"):
+        apply_phenotype_to_graph(
+            g, {"CYP1A2": "PM"},
+            phenotype_scale_overrides={"CYP1A2": -0.1},
+        )
+
+
+def test_override_for_gene_not_in_phenotypes_logs_info(caplog):
+    """Override key for a gene not in the phenotypes dict is silently ignored."""
+    g = _fresh_graph()
+    caplog.set_level(logging.INFO)
+    out = apply_phenotype_to_graph(
+        g, {"CYP1A2": "PM"},
+        phenotype_scale_overrides={"CYP2C9": 0.20},
+    )
+    # CYP2C9 abundance unchanged (override not applied because CYP2C9 not in phenotypes)
+    assert out.nodes["liver"].enzymes["CYP2C9"].mean == pytest.approx(
+        g.nodes["liver"].enzymes["CYP2C9"].mean
+    )
+    # logger.info note about ignored override
+    info_records = [r for r in caplog.records if r.levelno == logging.INFO and "ignored" in r.getMessage()]
+    assert info_records, "expected logger.info about ignored override key"
+
+
+def test_multiple_genes_overridden_independently():
+    g = _fresh_graph()
+    cyp_orig = g.nodes["liver"].enzymes["CYP1A2"].mean
+    nat2_orig = g.nodes["liver"].enzymes["NAT2"].mean
+
+    out = apply_phenotype_to_graph(
+        g,
+        {"CYP1A2": "PM", "NAT2": "IM"},
+        phenotype_scale_overrides={"CYP1A2": 0.40, "NAT2": 0.65},
+    )
+    assert out.nodes["liver"].enzymes["CYP1A2"].mean == pytest.approx(cyp_orig * 0.40)
+    assert out.nodes["liver"].enzymes["NAT2"].mean == pytest.approx(nat2_orig * 0.65)


### PR DESCRIPTION
## Summary
- Closes #31 — capability request from GenoADME (per-substrate effective phenotype scale injection)
- Adds `phenotype_scale_overrides: dict[str, float] | None` kwarg to `apply_phenotype_to_graph()` and `predict()`
- Flat `{gene: scale}` signature (simplified counter-proposal vs #31's 3-level dict — substrate dimension implicit in per-call SMILES; phenotype dimension implicit in per-call `phenotypes` argument)
- No calibration tables shipped — caller (GenoADME) resolves substrate→override mapping in their own meta-analysis layer

## Empirical (pravastatin SLCO1B1:PM)

| call | OATP1B1 abundance | Cmax (mg/L) | PM/EM ratio |
|---|---|---|---|
| EM (no phenotype) | 1.00× | 0.04218 | 1.000 |
| PM, no override | 0.10× (CPIC default) | 0.12800 | 3.034 |
| PM, override 0.30 | 0.30× | 0.07310 | **1.73** (compressed) |

Override compresses PM/EM Cmax shift toward EM, as required by the GenoADME use case (Niemi 2006 men-stratum target ~3.32 central).

## Test plan
- [x] `pytest tests/unit/test_phenotype_scale_overrides.py -v` — 7 PASS
- [x] `pytest tests/integration/test_phenotype_scale_overrides_pravastatin.py -v` — 2 PASS
- [x] `pytest tests/unit/test_phenotype.py tests/unit/test_pipeline_phenotypes.py -v` — all PASS (backward compat, 35/35)
- [x] `pytest tests/integration/test_holdout_regression.py -v` — Meta 2.679 invariant
- [x] Full suite: 849 PASS, 15 skipped, 7 xfailed (pre-existing)

## Architecture
- Engine: 0 line changes
- 107-holdout AAFE bit-identical
- v0.3.2 phenotype back-solve fix (PR #32) preserved — override applies BEFORE the pre-phenotype snapshot semantics

## Signature deviation note
Issue #31 originally proposed `{gene: {phenotype: {substrate: scale}}}` (3-level dict). The PR uses a flatter `{gene: scale}` shape because:
- substrate dimension is already implicit in per-call SMILES
- phenotype dimension is already implicit in the `phenotypes` argument of the same call

Mechanically equivalent for any single (gene, phenotype, substrate) tuple. Counter-proposal posted on #31 comment thread; if GenoADME pushes back, revising to 3-level is a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)