### PR TITLE
ci: gate full integration + regression tests on every PR (audit C1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,11 @@ jobs:
       - name: Unit tests
         run: pytest tests/unit -v --tb=short
 
-      - name: Engine validation integration
-        run: pytest tests/integration/test_engine_validation.py -v --tb=short
+      - name: Integration tests (full)
+        run: pytest tests/integration -v --tb=short
+
+      - name: Regression tests (registry pinning, holdout invariance, prodrug gates)
+        run: pytest tests/regression -v --tb=short
 
       - name: Benchmark smoke (N≤10 holdout drugs, slow marker)
         run: pytest tests/benchmark/test_holdout.py -v --tb=short


### PR DESCRIPTION
## Summary

External audit finding C1 (Hypatia review elevated to P1): CI was running only \`tests/integration/test_engine_validation.py\` (1 of 25 integration files) and zero \`tests/regression/\` files. The last 4 weeks of v0.3.x work (OATP/ECM, phenotype propagation, prodrug v3 registry, NAT2/UGT1A1, ECM auto-activation gating) had **no CI gate**.

## Local probe (post-archive relocation, main @ \`460c31c\`)

\`\`\`
pytest tests/integration  →  90 passed, 3 xfailed in 39s
pytest tests/regression   →  20 passed, 4 xfailed in 22s
\`\`\`

Combined ~62s wall clock. Well within 25-minute timeout. Auditor's concern about heavy-test slowness was overstated — \`test_holdout_regression\` uses cached predictions, not full benchmark sweep.

## CI now runs

- Unit tests (existing)
- **Integration tests (full)** — was: only test_engine_validation.py
- **Regression tests** — was: none
- Benchmark smoke (existing)

## Test plan

- [x] Local \`pytest tests/integration\` clean (90/3xf)
- [x] Local \`pytest tests/regression\` clean (20/4xf)
- [ ] CI green on this PR
- [ ] Verify a deliberately broken OATP test fails CI red on a follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)