### PR TITLE
fix(lockfile): pin numpy/rdkit to local-canonical (post-audit CI gap)

### DIFF
--- a/requirements-lock.txt
+++ b/requirements-lock.txt
@@ -2,7 +2,7 @@ exceptiongroup==1.3.1
 iniconfig==2.3.0
 joblib==1.5.3
 lightgbm==4.6.0
-numpy==2.2.6
+numpy==1.26.4
 nvidia-nccl-cu12==2.30.4 ; platform_system == "Linux"
 packaging==26.1
 pillow==12.2.0
@@ -10,7 +10,7 @@ pluggy==1.6.0
 Pygments==2.20.0
 pytest==9.0.3
 PyYAML==6.0.3
-rdkit==2026.3.1
+rdkit-pypi==2022.9.5
 ruff==0.15.11
 scikit-learn==1.7.2
 scipy==1.15.3


### PR DESCRIPTION
## Summary

**Audit-cycle gap discovered post-merge.** With \`tests/integration\` gated on CI by PR #38, 8 tests failed in CI runs of #38, #39, #40 — all merged anyway because branch protection didn't require checks. Same 8 tests pass locally.

## Root cause

Environment drift between CI lockfile and local dev env:

| Package | Local | CI (lockfile) | Result |
|---|---|---|---|
| **numpy** | **1.26.4** | **2.2.6** | major version diff |
| **rdkit** | **rdkit-pypi 2022.9.5** (import-resolved) | **rdkit 2026.3.1** | major version diff |
| scipy | 1.15.3 | 1.15.3 | OK |
| xgboost | 3.2.0 | 3.2.0 | OK |

The headline AAFE 2.679 in \`data/training/4track_holdout_predictions.json\` and all cached \"expected\" Cmax values in integration tests were generated on the local env. The H5 lockfile (PR #3, 2026-04-24) was captured on a different machine with newer libs and silently drifted for 4+ weeks because:
- Ruff was \`--exit-zero\` (advisory only)
- Only \`test_engine_validation.py\` was gated on CI

When PR #38 added full \`tests/integration\` to CI, the latent drift surfaced. **The audit C1 fix worked correctly; it exposed a real, pre-existing reproducibility gap.**

## 8 tests failing in CI (identical across PR #38, #39, #40)

| Test | Local result | CI drift |
|---|---|---|
| \`test_ecm_holdout_spot_check_10_drugs\` | pass | 6 drugs >5% (azacitidine 30%, amantadine 19%, alosetron 18%, ...) |
| \`test_oatp_ecm_statins[pravastatin]\` | FE 1.066 | FE 1.533 (gate 1.3) |
| \`test_oatp_ecm_statins[pitavastatin]\` | pass | FE 3.012 (gate 3.0) |
| \`test_phenotype_cyp_propagation[tizanidine]\` | 1.518 | 1.014 (gate 1.2) |
| \`test_phenotype_cyp_propagation[irbesartan]\` | 1.251 | 1.036 (gate 1.1) |
| \`test_predict_auto_ecm[pravastatin]\` | 0.0422 | 0.0294 (-30%) |
| \`test_predict_auto_ecm[fluvastatin]\` | 0.0583 | 0.0536 (-8%) |
| \`test_predict_auto_ecm[pitavastatin]\` | 0.00168 | 0.00116 (-31%) |

## Fix (surgical: two pin lines)

\`\`\`diff
- numpy==2.2.6
+ numpy==1.26.4
- rdkit==2026.3.1
+ rdkit-pypi==2022.9.5
\`\`\`

No code changes. No test changes.

## Why \`rdkit-pypi\` instead of \`rdkit\`

Local has BOTH \`rdkit==2023.9.6\` and \`rdkit-pypi==2022.9.5\` installed; Python import picks rdkit-pypi 2022.9.5 first. Tests + headline numbers were generated under \`rdkit.__version__ == \"2022.09.5\"\`. Pinning rdkit-pypi alone guarantees CI sees the same.

## Why \"Option B (downgrade)\" not \"Option A (regen headline)\"

- Headline AAFE 2.679 is preserved (no benchmark regen needed)
- Cached \"expected\" Cmax values in tests stay valid
- numpy 1.26.4 is LTS (EOL 2027) — no near-term security pressure
- numpy 2.x + rdkit 2026.x migration deserves its own spec cycle (descriptor / fingerprint drift audit)

## Test plan

- [ ] CI green on this PR (proves fix works)
- [ ] After merge, follow-up branch protection PR: require status checks on \`main\` (separately)

## Followup tracking

- Spec cycle: numpy 2.x + rdkit 2026.x migration audit
- Branch protection on \`main\` (auto-merge bypassed CI fail this round — separate concern from this lockfile fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)