### PR TITLE
ops(B): prospective public-only refresh + artifact-presence logs + skip helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,14 +290,14 @@ $$AAFE = 10^{\operatorname{mean}\left(\left|\log_{10}\frac{C_{max,pred}}{C_{max,
 
 The 4-track meta-learner combines mechanistic PBPK (Engine), data-driven XGBoost C<sub>max</sub> (ML), a closed-form CL/F analytical (CLF), and a conditional VDss analytical track. Weights are compound-type-adaptive and LOOCV-calibrated: base compounds blend Engine 0.60 / ML 0.40; other compounds use Engine 0.35 / ML 0.50 / CLF 0.15, with VDss 0.20 added when applicability criteria are satisfied (and the remaining tracks re-scaled by ×0.80 so the total is 1.0). In-domain AAFE (N=81) excludes 26 drugs flagged as out-of-applicability-domain (prodrugs, high-MW, extreme lipophilicity, extended-release formulation mismatch). The in-domain N shifted 79→81 vs the previous cache because the logp residual correction had pushed two drugs across the high-lipophilicity AD threshold.
 
-**Prospective validation** (FDA NMEs approved 2024–2025, curated 2026-04, never used in training or tuning):
+**Prospective validation** (FDA NMEs approved 2024–2025, curated 2026-04, never used in training or tuning; refreshed 2026-05-12 under public-clone state):
 
-| Slice | AAFE | 95% CI | %2-fold | N |
+| Slice | AAFE | %2-fold | N | Notes |
 |---|:-:|:-:|:-:|:-:|
-| All | 2.361 | [1.65, 3.50] | 53% | 15 |
-| In-domain | 2.043 | [1.46, 2.98] | — | 13 |
+| All | 2.402 | 53.3% | 15 | was 2.361 with DrugBank+logp_correction |
+| In-domain | 2.200 | 63.6% | 11 | was 2.043 (N=13); 2 drugs flipped to AD-flag under public-only logP |
 
-Prospective AAFE is below retrospective (2.361 &lt; 2.751), the opposite direction from classical over-fitting. However, N=15 is underpowered; CI spans 1.65–3.50. The 2.361 prospective number was computed on the local-developer state with DrugBank+logp_correction and is pending refresh under public-clone state in a follow-up commit (expected delta is small; only ~3 of 15 prospective drugs have DrugBank records).
+Prospective AAFE remains **below** retrospective (2.402 &lt; 2.751 overall; 2.200 &lt; 2.837 in-domain), the opposite direction from classical over-fitting on the 107-holdout. N=15 is underpowered; bootstrap 95% CIs are not refreshed in this slice (small N, narrative-only). Artifact: `data/validation/prospective_N15_public_only_2026-05-12.json`.
 
 **Cherry-picking caveat.** The 107-holdout has been used for ~47 configuration feedback cycles (track weights, routing, meta-learner variants). A quantitative audit (`docs/claude/cherry_picking_audit_2026-04-22.md`) scores aggregate risk 4.65/10 (moderate). The retrospective-contamination estimate (2.85–3.10 from the audit) brackets the new public-clone Meta point estimate 2.751, meaning the point estimate cannot statistically reject the null hypothesis that tuning inflated AAFE. A secondary permanent holdout (N50) is planned per `docs/claude/cherry_picking_process_v1.md`.
 

--- a/data/validation/prospective_N15_public_only_2026-05-12.json
+++ b/data/validation/prospective_N15_public_only_2026-05-12.json
@@ -1,0 +1,237 @@
+{
+  "context": "public-clone deterministic prospective N=15 (post 2026-05-09 audit honesty regen). DrugBank+logp_correction hidden.",
+  "n": 15,
+  "drugs": [
+    {
+      "name": "resmetirom",
+      "smiles": "CC(C)c1cc(Oc2c(Cl)cc(-n3nc(C#N)c(=O)[nH]c3=O)cc2Cl)n[nH]c1=O",
+      "dose_mg": 100.0,
+      "obs": 0.971,
+      "meta": 0.994350622342596,
+      "engine": 0.685764166644399,
+      "ml": 1.326015801495338,
+      "meta_fold": 1.0240480147709536,
+      "engine_fold": 1.41593866700753,
+      "ml_fold": 1.3656187451033348,
+      "in_ad": true,
+      "ad_flags": []
+    },
+    {
+      "name": "aficamten",
+      "smiles": "CCc1nc(-c2ccc3c(c2)CC[C@H]3NC(=O)c2cnn(C)c2)no1",
+      "dose_mg": 20.0,
+      "obs": 0.0705,
+      "meta": 0.10861425285305454,
+      "engine": 0.10890320127482567,
+      "ml": 0.0863320085722217,
+      "meta_fold": 1.5406277000433268,
+      "engine_fold": 1.5447262592173856,
+      "ml_fold": 1.224567497478322,
+      "in_ad": true,
+      "ad_flags": []
+    },
+    {
+      "name": "elafibranor",
+      "smiles": "CSc1ccc(C(=O)/C=C/c2cc(C)c(OC(C)(C)C(=O)O)c(C)c2)cc1",
+      "dose_mg": 120.0,
+      "obs": 0.802,
+      "meta": 0.9023937605249769,
+      "engine": 0.36379167297561926,
+      "ml": 1.9200861594276695,
+      "meta_fold": 1.1251792525249087,
+      "engine_fold": 2.204558431588259,
+      "ml_fold": 2.3941223933013336,
+      "in_ad": true,
+      "ad_flags": []
+    },
+    {
+      "name": "inavolisib",
+      "smiles": "C[C@H](Nc1ccc2c(c1)OCCn1cc(N3C(=O)OC[C@H]3C(F)F)nc1-2)C(N)=O",
+      "dose_mg": 9.0,
+      "obs": 0.035,
+      "meta": 0.02073832966226786,
+      "engine": 0.006186936586727796,
+      "ml": 0.0692692064265914,
+      "meta_fold": 1.6876961920265157,
+      "engine_fold": 5.65708077161837,
+      "ml_fold": 1.979120183616897,
+      "in_ad": true,
+      "ad_flags": []
+    },
+    {
+      "name": "danicopan",
+      "smiles": "CC(=O)c1nn(CC(=O)N2C[C@H](F)C[C@H]2C(=O)Nc2cccc(Br)n2)c2ccc(-c3cnc(C)nc3)cc12",
+      "dose_mg": 150.0,
+      "obs": 0.27,
+      "meta": 0.27363820963034313,
+      "engine": 0.11820927467187724,
+      "ml": 0.2585138151716132,
+      "meta_fold": 1.0134748504827522,
+      "engine_fold": 2.284084736578075,
+      "ml_fold": 1.0444316092769037,
+      "in_ad": false,
+      "ad_flags": [
+        "PGP_EFFLUX_RISK"
+      ]
+    },
+    {
+      "name": "berotralstat",
+      "smiles": "N#Cc1cccc([C@@H](NCC2CC2)c2ccc(F)c(NC(=O)c3cc(C(F)(F)F)nn3-c3cccc(CN)c3)c2)c1",
+      "dose_mg": 150.0,
+      "obs": 0.032,
+      "meta": 0.2531466844518896,
+      "engine": 0.14687137583325546,
+      "ml": 0.2300866042555239,
+      "meta_fold": 7.91083388912155,
+      "engine_fold": 4.589730494789233,
+      "ml_fold": 7.190206382985122,
+      "in_ad": false,
+      "ad_flags": [
+        "EXTREME_LIPOPHILIC",
+        "PGP_EFFLUX_RISK"
+      ]
+    },
+    {
+      "name": "vimseltinib",
+      "smiles": "Cc1nc(-c2cnc(NC(C)C)n(C)c2=O)ccc1Oc1ccnc(-c2cnn(C)c2)c1",
+      "dose_mg": 30.0,
+      "obs": 0.283,
+      "meta": 0.1633082274223967,
+      "engine": 0.09243432234171518,
+      "ml": 0.2192949304077873,
+      "meta_fold": 1.7329194276784385,
+      "engine_fold": 3.0616333070933694,
+      "ml_fold": 1.2904995089204783,
+      "in_ad": true,
+      "ad_flags": []
+    },
+    {
+      "name": "gepotidacin",
+      "smiles": "O=c1ccc2ncc(=O)n3c2n1C[C@H]3CN1CCC(NCc2cc3c(cn2)OCCC3)CC1",
+      "dose_mg": 1500.0,
+      "obs": 3.0,
+      "meta": 2.2759045510687432,
+      "engine": 0.677675042893719,
+      "ml": 3.2705755346416683,
+      "meta_fold": 1.3181572129601078,
+      "engine_fold": 4.426900520328731,
+      "ml_fold": 1.090191844880556,
+      "in_ad": true,
+      "ad_flags": []
+    },
+    {
+      "name": "taletrectinib",
+      "smiles": "C[C@@H](N)COc1ccc(-c2cnc3cc/c(=N/[C@H](C)c4cccc(F)c4)[nH]n23)cc1",
+      "dose_mg": 600.0,
+      "obs": 0.24,
+      "meta": 1.807220202913107,
+      "engine": 1.5113828329569645,
+      "ml": 1.175878756802017,
+      "meta_fold": 7.530084178804613,
+      "engine_fold": 6.297428470654019,
+      "ml_fold": 4.899494820008404,
+      "in_ad": true,
+      "ad_flags": []
+    },
+    {
+      "name": "suzetrigine",
+      "smiles": "COc1c([C@H]2[C@H](C(=O)Nc3ccnc(C(N)=O)c3)O[C@@](C)(C(F)(F)F)[C@H]2C)ccc(F)c1F",
+      "dose_mg": 100.0,
+      "obs": 0.62,
+      "meta": 0.5550920908170385,
+      "engine": 0.267851600569591,
+      "ml": 0.5450661871115923,
+      "meta_fold": 1.1169317852960645,
+      "engine_fold": 2.3147145609044686,
+      "ml_fold": 1.1374765389236416,
+      "in_ad": true,
+      "ad_flags": []
+    },
+    {
+      "name": "vorasidenib",
+      "smiles": "C[C@@H](Nc1nc(N[C@H](C)C(F)(F)F)nc(-c2cccc(Cl)n2)n1)C(F)(F)F",
+      "dose_mg": 40.0,
+      "obs": 0.0302,
+      "meta": 0.11813455743730715,
+      "engine": 0.12396582514785422,
+      "ml": 0.105397752897684,
+      "meta_fold": 3.911740312493614,
+      "engine_fold": 4.104828647279941,
+      "ml_fold": 3.4899918178041056,
+      "in_ad": true,
+      "ad_flags": []
+    },
+    {
+      "name": "pirtobrutinib",
+      "smiles": "COc1ccc(F)cc1C(=O)NCc1ccc(-c2nn([C@@H](C)C(F)(F)F)c(N)c2C(N)=O)cc1",
+      "dose_mg": 200.0,
+      "obs": 3.99,
+      "meta": 0.8244138152159616,
+      "engine": 0.43988805513949053,
+      "ml": 1.2139570408895104,
+      "meta_fold": 4.839802446729728,
+      "engine_fold": 9.070489533376287,
+      "ml_fold": 3.286771990775211,
+      "in_ad": true,
+      "ad_flags": []
+    },
+    {
+      "name": "pacritinib",
+      "smiles": "C1=C/COCc2cc(ccc2OCCN2CCCC2)Nc2nccc(n2)-c2cccc(c2)COC/1",
+      "dose_mg": 200.0,
+      "obs": 2.18,
+      "meta": 0.4058485777901111,
+      "engine": 0.4508340550402963,
+      "ml": 0.15922497284258036,
+      "meta_fold": 5.371461474302395,
+      "engine_fold": 4.835482092862635,
+      "ml_fold": 13.691319653452117,
+      "in_ad": true,
+      "ad_flags": []
+    },
+    {
+      "name": "crinecerfont",
+      "smiles": "C#CCN(c1nc(-c2cc(C)c(OC)cc2Cl)c(C)s1)[C@@H](CC1CC1)c1ccc(C)c(F)c1",
+      "dose_mg": 100.0,
+      "obs": 1.44,
+      "meta": 0.3386506391905536,
+      "engine": 0.49215269243992005,
+      "ml": 0.09485043722368139,
+      "meta_fold": 4.252169738825544,
+      "engine_fold": 2.9259212072192193,
+      "ml_fold": 15.181796121868313,
+      "in_ad": false,
+      "ad_flags": [
+        "EXTREME_LIPOPHILIC"
+      ]
+    },
+    {
+      "name": "revumenib",
+      "smiles": "CCN(C(=O)c1cc(F)ccc1Oc1cncnc1N1CC2(CCN(C[C@H]3CC[C@H](NS(=O)(=O)CC)CC3)CC2)C1)C(C)C",
+      "dose_mg": 270.0,
+      "obs": 1.172,
+      "meta": 0.4584620697582649,
+      "engine": 0.44259550387011326,
+      "ml": 0.3493561438760698,
+      "meta_fold": 2.556372876425666,
+      "engine_fold": 2.6480160547314147,
+      "ml_fold": 3.354742776230533,
+      "in_ad": false,
+      "ad_flags": [
+        "PGP_EFFLUX_RISK"
+      ]
+    }
+  ],
+  "overall": {
+    "meta_aafe": 2.401657547448248,
+    "engine_aafe": 3.3607647826976694,
+    "ml_aafe": 2.7423858026665147,
+    "pct_2fold": 53.333333333333336,
+    "pct_3fold": 60.0
+  },
+  "in_domain": {
+    "n": 11,
+    "meta_aafe": 2.2003438935779767,
+    "pct_2fold": 63.63636363636363
+  }
+}

--- a/src/sisyphus/predict/chemistry.py
+++ b/src/sisyphus/predict/chemistry.py
@@ -377,7 +377,10 @@ def compute_profile(smiles: str) -> MolecularProfile:
     if db_logp is not None:
         logp = db_logp  # experimental overrides Crippen
 
-    # logP correction (residual learning) — only for Crippen, not experimental
+    # logP correction (residual learning) — only for Crippen, not experimental.
+    # NOTE: this model is gitignored (`models/adme/logp_correction.json`). When
+    # present locally it shifts headline AAFE by ~+2.7% (favourably); CI/public
+    # clones run without it. See AGENTS.md §"Artifact gates".
     _LOGP_CORR_PATH = Path(__file__).resolve().parent.parent.parent.parent / "models" / "adme" / "logp_correction.json"  # noqa: E501
     if db_logp is None and _LOGP_CORR_PATH.exists():
         try:
@@ -386,6 +389,11 @@ def compute_profile(smiles: str) -> MolecularProfile:
                 m = xgb.XGBRegressor()
                 m.load_model(str(_LOGP_CORR_PATH))
                 compute_profile._logp_model = m  # type: ignore[attr-defined]
+                logger.info(
+                    "logp_correction: enriched (gitignored artifact present at %s); "
+                    "predictions will differ from public-clone state by O(1-5%%)",
+                    _LOGP_CORR_PATH,
+                )
             import numpy as np
             corr_features = np.array([[logp, mw, tpsa, float(hbd), float(hba), float(rotatable_bonds)]])  # noqa: E501
             correction = float(compute_profile._logp_model.predict(corr_features)[0])  # type: ignore[attr-defined]

--- a/src/sisyphus/predict/drugbank.py
+++ b/src/sisyphus/predict/drugbank.py
@@ -77,13 +77,26 @@ class DrugBankLookup:
         if self._loaded:
             return
         self._loaded = True
+        if not (self._data_dir / "drugs.csv").exists():
+            # Public-clone state — DrugBank not present. Silent until queried,
+            # then this single message announces the fallback at first use.
+            logger.info(
+                "DrugBank not present at %s — running in public-clone deterministic "
+                "state. fup/pKa/logP enrichments will not apply. See AGENTS.md "
+                "§\"Artifact gates\" for the headline AAFE footprint (~+2.7%% when "
+                "absent vs present).",
+                self._data_dir,
+            )
+            return
         self._load_drugs()
         self._load_enzymes()
         self._load_pk_data()
         self._load_experimental()
         logger.info(
-            "DrugBank loaded: %d SMILES, %d InChIKey, %d enzyme, %d fup, %d pka, %d logp",
-            len(self._smiles_to_id), len(self._inchikey14_to_id),
+            "DrugBank loaded from %s — enriching %d SMILES, %d InChIKey, %d enzyme, "
+            "%d fup, %d pka, %d logp. Predictions will differ from public-clone "
+            "state; see AGENTS.md §\"Artifact gates\".",
+            self._data_dir, len(self._smiles_to_id), len(self._inchikey14_to_id),
             len(self._enzyme_substrates), len(self._fup), len(self._pka), len(self._logp),
         )
 

--- a/tests/_artifact_helpers.py
+++ b/tests/_artifact_helpers.py
@@ -1,0 +1,65 @@
+"""Shared skip markers for proprietary-artifact-sensitive tests.
+
+The 2026-05-09 audit established that two gitignored artifacts —
+`data/drugbank/` and `models/adme/logp_correction.json` — silently shift
+predict() Cmax values by 5–30% on covered drugs. The public-clone state
+(no artifacts) is the SSOT for tests + CI; local-developer state with
+artifacts present is for personal use only.
+
+Tests that pin numerical Cmax values to the public-only canonical fail
+locally when artifacts are present. Tests that *require* artifact-derived
+enrichment (e.g., DrugBank fm fractions) fail in CI / public clones.
+
+Use the markers in this module so both cases skip with an informative
+message rather than failing opaquely.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+_DRUGBANK_FILE = ROOT / "data" / "drugbank" / "drugs.csv"
+_LOGP_CORRECTION_FILE = ROOT / "models" / "adme" / "logp_correction.json"
+
+PROPRIETARY_ARTIFACTS_PRESENT = _DRUGBANK_FILE.exists() or _LOGP_CORRECTION_FILE.exists()
+DRUGBANK_PRESENT = _DRUGBANK_FILE.exists()
+
+
+def _public_only_reason() -> str:
+    present = []
+    if _DRUGBANK_FILE.exists():
+        present.append(str(_DRUGBANK_FILE.relative_to(ROOT)))
+    if _LOGP_CORRECTION_FILE.exists():
+        present.append(str(_LOGP_CORRECTION_FILE.relative_to(ROOT)))
+    return (
+        f"Local-developer artifact(s) present: {', '.join(present)}. "
+        "This test is anchored to public-clone deterministic Cmax values "
+        "(see AGENTS.md §\"Artifact gates\"). To run it locally, hide the "
+        "artifact(s) first: `mv data/drugbank data/drugbank.local-archive` "
+        "and/or `mv models/adme/logp_correction.json{,.local-archive}`. CI "
+        "runs without these artifacts and evaluates the test normally."
+    )
+
+
+def _drugbank_required_reason() -> str:
+    return (
+        "DrugBank artifacts not present at `data/drugbank/` (academic license "
+        "required; gitignored). This test relies on DrugBank-enriched fm fractions "
+        "or other experimental properties. Engine-level architectural correctness "
+        "is verified separately (see e.g. tests/unit/test_phenotype.py)."
+    )
+
+
+# Marker for tests anchored to public-only Cmax canonical values
+# (e.g., test_predict_auto_ecm.py's pinned 0.0294 mg/L pravastatin).
+skip_if_local_artifacts = pytest.mark.skipif(
+    PROPRIETARY_ARTIFACTS_PRESENT, reason=_public_only_reason(),
+)
+
+# Marker for tests that require DrugBank enrichment to produce
+# measurable mechanistic effect (e.g., single-CYP PM/EM ratios).
+skip_if_no_drugbank = pytest.mark.skipif(
+    not DRUGBANK_PRESENT, reason=_drugbank_required_reason(),
+)

--- a/tests/integration/test_ecm_holdout_regression.py
+++ b/tests/integration/test_ecm_holdout_regression.py
@@ -12,9 +12,12 @@ import pathlib
 
 import pytest
 
+from tests._artifact_helpers import skip_if_local_artifacts
+
 _CACHE = pathlib.Path("data/training/4track_holdout_predictions.json")
 
 
+@skip_if_local_artifacts
 @pytest.mark.slow
 def test_ecm_holdout_spot_check_10_drugs():
     """Per-drug Meta Cmax must match cached 4track predictions within 5%."""

--- a/tests/integration/test_predict_auto_ecm.py
+++ b/tests/integration/test_predict_auto_ecm.py
@@ -28,6 +28,7 @@ import numpy as np
 import pytest
 
 from sisyphus.pipeline.predict import predict
+from tests._artifact_helpers import skip_if_local_artifacts
 
 _PRAVA_SMILES = (
     "CC[C@@H](C)C(=O)O[C@@H]1C[C@H](C=C2[C@@H]1CC[C@H]"
@@ -43,6 +44,7 @@ _PITA_SMILES = (
 )
 
 
+@skip_if_local_artifacts
 @pytest.mark.slow
 def test_pravastatin_auto_ecm_activates():
     """predict(pravastatin) auto-activates ECM and produces the FDA-anchored Cmax."""
@@ -60,6 +62,7 @@ def test_pravastatin_auto_ecm_activates():
     )
 
 
+@skip_if_local_artifacts
 @pytest.mark.slow
 def test_fluvastatin_no_auto_ecm():
     """predict(fluvastatin) does NOT auto-activate ECM (CYP2C9-dominant per Niemi 2009)."""
@@ -77,6 +80,7 @@ def test_fluvastatin_no_auto_ecm():
     )
 
 
+@skip_if_local_artifacts
 @pytest.mark.slow
 def test_pitavastatin_auto_ecm_activates():
     """predict(pitavastatin) auto-activates ECM under v0.3.1 promotion.
@@ -85,7 +89,7 @@ def test_pitavastatin_auto_ecm_activates():
     metabolic_fraction=0 (parallel pravastatin justification: Niemi 2009
     PM/EM ~3x; OATP1B1 hepatic uptake is rate-limiting).
 
-    EMPIRICAL NOTE: pitavastatin Cmax under auto-ECM is 0.00116 mg/L
+    EMPIRICAL NOTE (public-clone): pitavastatin Cmax under auto-ECM is 0.00116 mg/L
     (FE 3.012x under FDA Livalo 0.0035) on a public-clone deterministic
     state. With DrugBank+logp_correction enrichment local-developer Cmax
     was 0.00168 (FE 2.08). The under-prediction reflects a combination of
@@ -96,6 +100,7 @@ def test_pitavastatin_auto_ecm_activates():
     improvement is deferred to per-drug Jmax/PS curation + DrugBank-
     independent fm allocation work.
     """
+    # marker applied above via decorator on this function (see definition below)
     result = predict(_PITA_SMILES, dose_mg=2.0, route="oral", n_mc_samples=0)
     assert result.engine_pk is not None
     cmax = result.engine_pk.cmax.mean

--- a/tests/regression/test_prodrug_v2_snapshot.py
+++ b/tests/regression/test_prodrug_v2_snapshot.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import pytest
 
 from sisyphus.pipeline.predict import predict
+from tests._artifact_helpers import skip_if_local_artifacts
 
 _PINNED = {
     "sepiapterin":       8.679384e+00,
@@ -56,6 +57,7 @@ _DOSE_ROUTE = {
 }
 
 
+@skip_if_local_artifacts
 @pytest.mark.parametrize("drug_name", list(_PINNED.keys()))
 def test_cmax_snapshot(drug_name):
     pinned = _PINNED[drug_name]

--- a/tests/regression/test_prodrug_v2_validation_gate.py
+++ b/tests/regression/test_prodrug_v2_validation_gate.py
@@ -55,6 +55,7 @@ from __future__ import annotations
 import pytest
 
 from sisyphus.pipeline.predict import predict
+from tests._artifact_helpers import skip_if_local_artifacts
 
 _CLINICAL_CMAX = {
     "sepiapterin":       0.0024,
@@ -102,6 +103,7 @@ _KNOWN_FAILURES = {
 }
 
 
+@skip_if_local_artifacts
 @pytest.mark.parametrize(
     "drug_name",
     [


### PR DESCRIPTION
## Summary

Batch B post-cycle hygiene. Three small threads, single PR.

### (1) Prospective slice refresh under public-clone state

Re-ran the N=15 FDA NMEs 2024–2025 prospective benchmark with both proprietary artifacts hidden:

| Slice | Public-only AAFE | %2-fold | N | (was with artifacts) |
|---|---|---|---|---|
| Overall | **2.402** | 53.3% | 15 | 2.361 |
| In-domain | **2.200** | 63.6% | 11 | 2.043 (N=13) |

In-domain N shifted 13→11 because 2 drugs flip to AD-flag under public-only logP (logp_correction had nudged them across the high-lipophilicity threshold). Prospective AAFE remains **below** retrospective (2.402 < 2.751 / 2.200 < 2.837) — still no over-fitting signal.

Artifact: \`data/validation/prospective_N15_public_only_2026-05-12.json\`.

### (2) Artifact-presence runtime logs

\`predict/drugbank.py\` + \`predict/chemistry.py\` emit a single \`logger.info\` at artifact-load decision points:

- DrugBank present → \"DrugBank loaded from ... enriching N fields ...\"
- DrugBank absent → \"DrugBank not present at ... running in public-clone deterministic state\"
- logp_correction present → \"logp_correction: enriched (gitignored artifact present); predictions will differ from public-clone state by O(1-5%)\"

Fires once per process. Makes the silent fallback path visible to anyone who spot-checks logs. Pairs with AGENTS.md §\"Artifact gates\".

### (3) Centralized skip markers for public-only-anchored tests

\`tests/_artifact_helpers.py\` (new) exports:

- \`skip_if_local_artifacts\` — for tests anchored to public-only Cmax values (e.g. \`test_predict_auto_ecm[pravastatin]\` expects 0.0294 mg/L; locally with DrugBank+logp_correction it's 0.0422)
- \`skip_if_no_drugbank\` — for tests that require DrugBank enrichment

Applied to 5 test modules covering the 9 tests that failed locally with artifacts present in the previous state. Local sweep result:

\`\`\`
Before: 101 passed, 1 skipped, 3 xfailed, 9 FAILED   (artifacts present)
After:  101 passed, 13 skipped, 3 xfailed             (artifacts present)
CI:     unchanged shape (PR #43 baseline; CI has no artifacts)
\`\`\`

The skip messages explicitly tell devs how to reproduce CI state: \`mv data/drugbank data/drugbank.local-archive\`.

## Test plan

- [x] Local sweep with artifacts present: 101 pass / 13 skip / 3 xfail
- [x] Local sweep with artifacts hidden (CI-equivalent on affected modules): 11 pass / 2 skip / 3 xfail
- [x] Prospective regen artifact committed
- [x] README §Prospective table updated
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)