### PR TITLE
chore(gitignore): add linter caches, conflict artifacts, manuscript drafts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,10 +30,19 @@ venv/
 Thumbs.db
 *:Zone.Identifier
 
+# Merge / patch conflict artifacts
+*.orig
+*.rej
+
 # Testing
 .pytest_cache/
 .coverage
 htmlcov/
+.hypothesis/
+
+# Linter / type-checker caches
+.ruff_cache/
+.mypy_cache/
 
 # Jupyter
 .ipynb_checkpoints/
@@ -65,3 +74,7 @@ CLAUDE.md
 # docs/_internal/AGENT_INTERNAL.md superset is kept local-only because external
 # readers don't need the day-to-day scratchpad (untracked by user request 2026-05-30).
 docs/_internal/
+
+# Manuscript drafts (local-only; binary, frequently revised — not version-tracked)
+Sisyphus_Preprint_*.docx
+Sisyphus_Preprint_*.pdf


### PR DESCRIPTION
## What

Adds a few missing `.gitignore` rules for caches and local-only artifacts. **No tracked files are affected** — every target was untracked or absent.

| Rule | Why |
|---|---|
| `.ruff_cache/`, `.mypy_cache/` | Linter / type-checker caches. `ruff` is the project linter (line length 100); these regenerate and were not yet ignored (`.ruff_cache/` was present on disk, unignored). |
| `.hypothesis/` | Property-test cache. |
| `*.orig`, `*.rej` | Merge / patch conflict leftovers. |
| `Sisyphus_Preprint_*.docx`, `Sisyphus_Preprint_*.pdf` | Manuscript drafts kept local-only — binary, frequently revised, not meaningful to version-track (they were sitting untracked in `git status`). |

## Not touched

`archive/contaminated/*.bak` (9.7 MB) are **intentionally tracked** — a forensic baseline of pre-2026-04-04 holdout-leak models (commit `db75a4e`), kept so a future suspiciously-good result can be diffed against the contamination signature (~0.4 AAFE better). Left as-is.

## Verification

- `git check-ignore` confirms all 4 new patterns match their targets.
- `git status` working tree is clean after the change (preprints no longer shown as untracked).
- Builds on top of #51 (`965ed1b`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
