### PR TITLE
fix: close pravastatin MMPK holdout leak + harden JAX RHS against silent flux drop

### DIFF
--- a/data/training/mmpk_expanded_full.csv
+++ b/data/training/mmpk_expanded_full.csv
@@ -1238,9 +1238,9 @@ topotecan,CC[C@@]1(O)C(=O)OCc2c1cc1n(c2=O)Cc2cc3c(CN(C)C)c(O)ccc3nc2-1,2.6,0.005
 topotecan,CC[C@@]1(O)C(=O)OCc2c1cc1n(c2=O)Cc2cc3c(CN(C)C)c(O)ccc3nc2-1,3.29,0.0086,-2.5826974467064066,1,1.35,4.32,35.82,36.0,solution,False,False
 lovastatin acid,CC[C@H](C)C(=O)O[C@H]1C[C@@H](C)C=C2C=C[C@H](C)[C@H](CC[C@@H](O)C[C@@H](O)CC(=O)O)[C@H]21,80.0,0.00466,-4.234704070301944,1,5.0,2.64,33.71,,tablet,True,False
 lovastatin,CC[C@H](C)C(=O)O[C@H]1C[C@@H](C)C=C2C=C[C@H](C)[C@H](CC[C@@H]3C[C@@H](O)CC(=O)O3)[C@H]21,80.0,0.0060699999999999,-4.119901295916686,1,3.5,2.6,43.1,5.0,tablet,False,False
-pravastatin,CC[C@H](C)C(=O)O[C@H]1C[C@H](O)C=C2C=C[C@H](C)[C@H](CC[C@@H](O)C[C@@H](O)CC(=O)O)[C@H]21,10.0,0.0113342842738304,-2.9456058990698826,2,1.13,2.4450000000000003,33.92,,tablet,False,False
-pravastatin,CC[C@H](C)C(=O)O[C@H]1C[C@H](O)C=C2C=C[C@H](C)[C@H](CC[C@@H](O)C[C@@H](O)CC(=O)O)[C@H]21,19.2,0.0273999999999999,-2.8455506658831617,1,0.88,1.77,66.2,18.0,solution,False,False
-pravastatin,CC[C@H](C)C(=O)O[C@H]1C[C@H](O)C=C2C=C[C@H](C)[C@H](CC[C@@H](O)C[C@@H](O)CC(=O)O)[C@H]21,40.0,0.0351999999999999,-3.0555173278498318,1,1.4,1.6,71.2,,tablet,False,False
+pravastatin,CC[C@H](C)C(=O)O[C@H]1C[C@H](O)C=C2C=C[C@H](C)[C@H](CC[C@@H](O)C[C@@H](O)CC(=O)O)[C@H]21,10.0,0.0113342842738304,-2.9456058990698826,2,1.13,2.4450000000000003,33.92,,tablet,False,True
+pravastatin,CC[C@H](C)C(=O)O[C@H]1C[C@H](O)C=C2C=C[C@H](C)[C@H](CC[C@@H](O)C[C@@H](O)CC(=O)O)[C@H]21,19.2,0.0273999999999999,-2.8455506658831617,1,0.88,1.77,66.2,18.0,solution,False,True
+pravastatin,CC[C@H](C)C(=O)O[C@H]1C[C@H](O)C=C2C=C[C@H](C)[C@H](CC[C@@H](O)C[C@@H](O)CC(=O)O)[C@H]21,40.0,0.0351999999999999,-3.0555173278498318,1,1.4,1.6,71.2,,tablet,False,True
 idelalisib,CC[C@H](Nc1ncnc2[nH]cnc12)c1nc2cccc(F)c2c(=O)n1-c1ccccc1,150.0,2.239256917063456,-1.82598733463168,3,2.0,9.0,10507.6,,,False,False
 levacetylmethadol (laam),CC[C@H](OC(C)=O)C(C[C@H](C)N(C)C)(c1ccccc1)c1ccccc1,5.0,0.0048799999999999,-3.0105501823333083,1,2.12,43.1,39.6,,solution,False,False
 levacetylmethadol (laam),CC[C@H](OC(C)=O)C(C[C@H](C)N(C)C)(c1ccccc1)c1ccccc1,20.0,0.0389999999999999,-2.709965388637482,1,2.5,,393.0,48.0,solution,False,False

--- a/data/training/mmpk_expanded_v2.csv
+++ b/data/training/mmpk_expanded_v2.csv
@@ -1238,9 +1238,9 @@ topotecan,CC[C@@]1(O)C(=O)OCc2c1cc1n(c2=O)Cc2cc3c(CN(C)C)c(O)ccc3nc2-1,2.6,0.005
 topotecan,CC[C@@]1(O)C(=O)OCc2c1cc1n(c2=O)Cc2cc3c(CN(C)C)c(O)ccc3nc2-1,3.29,0.0086,-2.5826974467064066,1,1.35,4.32,35.82,36.0,solution,False,False
 lovastatin acid,CC[C@H](C)C(=O)O[C@H]1C[C@@H](C)C=C2C=C[C@H](C)[C@H](CC[C@@H](O)C[C@@H](O)CC(=O)O)[C@H]21,80.0,0.00466,-4.234704070301944,1,5.0,2.64,33.71,,tablet,True,False
 lovastatin,CC[C@H](C)C(=O)O[C@H]1C[C@@H](C)C=C2C=C[C@H](C)[C@H](CC[C@@H]3C[C@@H](O)CC(=O)O3)[C@H]21,80.0,0.0060699999999999,-4.119901295916686,1,3.5,2.6,43.1,5.0,tablet,False,False
-pravastatin,CC[C@H](C)C(=O)O[C@H]1C[C@H](O)C=C2C=C[C@H](C)[C@H](CC[C@@H](O)C[C@@H](O)CC(=O)O)[C@H]21,10.0,0.0113342842738304,-2.9456058990698826,2,1.13,2.4450000000000003,33.92,,tablet,False,False
-pravastatin,CC[C@H](C)C(=O)O[C@H]1C[C@H](O)C=C2C=C[C@H](C)[C@H](CC[C@@H](O)C[C@@H](O)CC(=O)O)[C@H]21,19.2,0.0273999999999999,-2.8455506658831617,1,0.88,1.77,66.2,18.0,solution,False,False
-pravastatin,CC[C@H](C)C(=O)O[C@H]1C[C@H](O)C=C2C=C[C@H](C)[C@H](CC[C@@H](O)C[C@@H](O)CC(=O)O)[C@H]21,40.0,0.0351999999999999,-3.0555173278498318,1,1.4,1.6,71.2,,tablet,False,False
+pravastatin,CC[C@H](C)C(=O)O[C@H]1C[C@H](O)C=C2C=C[C@H](C)[C@H](CC[C@@H](O)C[C@@H](O)CC(=O)O)[C@H]21,10.0,0.0113342842738304,-2.9456058990698826,2,1.13,2.4450000000000003,33.92,,tablet,False,True
+pravastatin,CC[C@H](C)C(=O)O[C@H]1C[C@H](O)C=C2C=C[C@H](C)[C@H](CC[C@@H](O)C[C@@H](O)CC(=O)O)[C@H]21,19.2,0.0273999999999999,-2.8455506658831617,1,0.88,1.77,66.2,18.0,solution,False,True
+pravastatin,CC[C@H](C)C(=O)O[C@H]1C[C@H](O)C=C2C=C[C@H](C)[C@H](CC[C@@H](O)C[C@@H](O)CC(=O)O)[C@H]21,40.0,0.0351999999999999,-3.0555173278498318,1,1.4,1.6,71.2,,tablet,False,True
 idelalisib,CC[C@H](Nc1ncnc2[nH]cnc12)c1nc2cccc(F)c2c(=O)n1-c1ccccc1,150.0,2.239256917063456,-1.82598733463168,3,2.0,9.0,10507.6,,,False,False
 levacetylmethadol (laam),CC[C@H](OC(C)=O)C(C[C@H](C)N(C)C)(c1ccccc1)c1ccccc1,5.0,0.0048799999999999,-3.0105501823333083,1,2.12,43.1,39.6,,solution,False,False
 levacetylmethadol (laam),CC[C@H](OC(C)=O)C(C[C@H](C)N(C)C)(c1ccccc1)c1ccccc1,20.0,0.0389999999999999,-2.709965388637482,1,2.5,,393.0,48.0,solution,False,False

--- a/docs/claude/experiment-log.md
+++ b/docs/claude/experiment-log.md
@@ -1,5 +1,5 @@
 ---
-last_updated: 2026-05-30
+last_updated: 2026-05-31
 parent: ../../CLAUDE.md
 charter: Chronological log of Sisyphus experiments (successes, negatives, infrastructure). Latest first.
 ---
@@ -7,6 +7,22 @@ charter: Chronological log of Sisyphus experiments (successes, negatives, infras
 # Experiment Log
 
 Reverse-chronological. Top-level [CLAUDE.md](../../CLAUDE.md) carries only the **current** headline numbers; this file is the history. For the authoritative failed-experiment list (with do-not-retry gating), see [dead-ends.md](./dead-ends.md). For the why-accuracy-is-bounded analysis, see [diagnosis.md](./diagnosis.md).
+
+---
+
+## 2026-05-31 — Full-codebase completeness audit + 3 hardening fixes (no metric change)
+
+**Trigger:** user request — full architecture/completeness evaluation. A 29-agent adversarial workflow (7 dimensions: invariants, engine, predict/ml, tests, data/science, docs, roadmap; each load-bearing claim refuted by an independent skeptic; synthesis siding with verifiers).
+
+**Audit verdict:** overall **B+ / ~77**. The three load-bearing ideas (body-as-graph, all-Distribution, engine-knows-types-not-identities) survive adversarial scrutiny; the invariants that matter for correctness/integrity (engine identity-blindness, mass conservation, holdout exclusion, no-fudge) all hold under direct verification. Drag is integration/bookkeeping debt, not correctness. Two audit alarms self-corrected at the verification stage: the holdout leak-guard *does* run in CI (the slow-marker mechanism was refuted), and the `engine→ml` import is dormant-dead (function-local, gated on `backend="surrogate"` which no shipped path passes), not a live dependency.
+
+**Fix 1 — CLAUDE.md headline reconcile (the audit's #1, independently found by 5/7 dimensions).** The metrics block was stale at the 2026-05-25 B-03.x state (Meta 2.772 / In-domain 2.862 / N=81); the shipped cache (`4track_holdout_predictions.json` overall.meta=**2.69825**, in_domain.n=**79**), the README table, and the pinned test `test_cached_holdout_aafe_is_2p698` all read 2.698 / N=79. Reconciled the table + caption + † note to the cache. CLAUDE.md is git-untracked (`9006cf9`), so the headline is unguarded — drift is the expected failure mode (local-only edit, no commit).
+
+**Fix 2 — pravastatin holdout→MMPK leak (severity corrected from the audit).** The audit called it a "live leak in the shipped numbers"; deeper tracing shows that is **overstated**. The shipped `xgboost_cmax.json` (`v3_clean`, 2026-04-04) was trained on Omega's `mmpk_clean.csv` with its own N=107 3-key exclusion — *not* via the in-repo `ml_cmax_improvement.load_mmpk_data`, which saves no model. What is real and forward-looking: pravastatin is the **only** holdout drug (1/107, verified by replicating the two-filter logic) surviving both in-repo filters — `in_holdout=False` rows + an InChIKey-14 mismatch (clinical_pk `GOSGZXISMCZCDW` vs MMPK `TUZYXOIXSAXUGO`) the `ho_ik` filter can't catch (the other ~70 holdout drugs in the corpus are correctly excluded by InChIKey). Corrected the `in_holdout` flag in both `mmpk_expanded_{full,v2}.csv` (the universal first-line filter), added a name-based exclusion to `load_mmpk_data` (defense-in-depth, mirrors `build_n50_exclusion.py`), and added `tests/regression/test_mmpk_holdout_leak.py`. Commit `c957507`.
+
+**Fix 3 — JAX RHS silent-drop guard.** `ProdrugActivationFluxSpec`/`OneCompartmentEliminationFluxSpec` had no branch in `make_jax_rhs` and no terminal else → silently dropped from the JAX RHS (dead path; no production caller uses `backend="jax"`; JAX absent from the lockfile). Added a pure-Python `_unsupported_flux_specs()` guard that raises `NotImplementedError`, unit-tested without JAX so it runs in CI. Engine identity-blindness preserved (type-based dispatch, no name logic). Commit `49d9f69`.
+
+**Metrics:** **unchanged.** None of the three touches the prediction/benchmark path or model artifacts — Fix 1 is a doc reconcile, Fix 2 is forward-looking data/loader hardening (shipped model unaffected), Fix 3 guards a dead path. Cache stays Meta 2.69825 / N=79. Fixes 2–3 on branch `fix/audit-followups`; Fix 1 is a local-only CLAUDE.md edit.
 
 ---
 

--- a/scripts/ml_cmax_improvement.py
+++ b/scripts/ml_cmax_improvement.py
@@ -63,6 +63,15 @@ def load_holdout_ik():
             if ik: ik_set.add(ik)
     return ik_set
 
+def load_holdout_names() -> set[str]:
+    """Lowercased reference drug names (holdout + train) for name-based training
+    exclusion — robust to the SMILES-representation drift that can defeat
+    load_holdout_ik (a different InChIKey-14 for the same drug). Mirrors the
+    name-based policy in build_n50_exclusion.py."""
+    with open(ROOT / "data/reference/holdout.json") as f:
+        hd = json.load(f)
+    return {n.lower().strip() for n in hd.get("holdout", []) + hd.get("train", [])}
+
 def scaffold_split(smiles_list, n_folds=5, seed=42):
     s2i = {}
     for i, smi in enumerate(smiles_list):
@@ -122,8 +131,14 @@ def compute_mordred(smi):
 
 def load_mmpk_data():
     ho_ik = load_holdout_ik()
+    ho_names = load_holdout_names()
     mmpk = pd.read_csv(ROOT / "data/training/mmpk_expanded_full.csv")
     mmpk = mmpk[~mmpk["in_holdout"]].reset_index(drop=True)
+    # Name-based holdout exclusion (defense-in-depth): catches reference drugs
+    # whose MMPK canon_smiles yields a different InChIKey-14 than their
+    # clinical_pk SMILES, so the ho_ik filter below would miss them (e.g.
+    # pravastatin: clinical_pk GOSGZXISMCZCDW vs MMPK TUZYXOIXSAXUGO).
+    mmpk = mmpk[~mmpk["name"].str.lower().isin(ho_names)].reset_index(drop=True)
 
     # Per-drug: take median entry
     dedup = mmpk.groupby("canon_smiles").agg(

--- a/src/sisyphus/engine/rhs_jax.py
+++ b/src/sisyphus/engine/rhs_jax.py
@@ -50,6 +50,29 @@ from sisyphus.engine.flux import (
     TransitFluxSpec,
 )
 
+# Concrete FluxSpec subclasses the JAX RHS can vectorize. ProdrugActivation and
+# OneCompartmentElimination are intentionally absent — they have no JAX branch.
+# Before _unsupported_flux_specs() guarded make_jax_rhs, such specs fell through
+# the build loop silently, omitting their flux from the RHS.
+_JAX_SUPPORTED_FLUX = (
+    FlowFluxSpec,
+    ClearanceFluxSpec,
+    TransitFluxSpec,
+    AbsorptionFluxSpec,
+    DiffusionFluxSpec,
+    ActiveTransportFluxSpec,
+)
+
+
+def _unsupported_flux_specs(flux_specs):
+    """Return the flux specs whose type the JAX RHS cannot vectorize.
+
+    Pure Python (imports no JAX) so the "no silent drop" invariant is testable
+    even when JAX is not installed.
+    """
+    return [s for s in flux_specs if not isinstance(s, _JAX_SUPPORTED_FLUX)]
+
+
 # ---------------------------------------------------------------------------
 # make_jax_rhs — the public API
 # ---------------------------------------------------------------------------
@@ -82,6 +105,18 @@ def make_jax_rhs(
         )
 
     n_states = compiled.n_states
+
+    # Fail loudly rather than silently dropping a flux the JAX RHS cannot
+    # vectorize (e.g. ProdrugActivation / OneCompartmentElimination). The
+    # SciPy backend handles them; backend="jax" must not corrupt those graphs.
+    unsupported = _unsupported_flux_specs(compiled.flux_specs)
+    if unsupported:
+        names = sorted({type(s).__name__ for s in unsupported})
+        raise NotImplementedError(
+            f"JAX RHS cannot vectorize flux type(s) {names}; they would be "
+            f"silently dropped. Use backend='scipy' (default) or add a "
+            f"vmap-safe branch to rhs_jax.py."
+        )
 
     # -- Extract static topology per flux type (Python, not JAX) ------------
     # Each list collects (source_idx, target_idx, edge_id) for that flux type.

--- a/tests/regression/test_mmpk_holdout_leak.py
+++ b/tests/regression/test_mmpk_holdout_leak.py
@@ -1,0 +1,94 @@
+"""Invariant #5 guard: no holdout drug may enter the ML Cmax (MMPK) training set.
+
+A holdout drug leaks into the MMPK corpus only if it survives BOTH filters in
+``scripts/ml_cmax_improvement.py::load_mmpk_data`` — an ``in_holdout=False`` row
+AND a ``canon_smiles`` InChIKey-14 absent from the holdout key set (built from
+clinical_pk SMILES). Pravastatin slipped both (connectivity-level SMILES
+mismatch: clinical_pk ``GOSGZXISMCZCDW`` vs MMPK ``TUZYXOIXSAXUGO``) until its
+``in_holdout`` flag was corrected and a name-based exclusion added. These tests
+pin the invariant and catch any future SMILES-representation drift.
+"""
+from __future__ import annotations
+
+import csv
+import json
+import pathlib
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+_MMPK = [
+    ROOT / "data/training/mmpk_expanded_full.csv",
+    ROOT / "data/training/mmpk_expanded_v2.csv",
+]
+_HOLDOUT = json.loads((ROOT / "data/reference/holdout.json").read_text())
+_HOLDOUT_NAMES = {n.lower().strip() for n in _HOLDOUT.get("holdout", [])}
+
+
+def _rows(path: pathlib.Path) -> list[dict]:
+    with path.open(newline="") as f:
+        return list(csv.DictReader(f))
+
+
+def test_pravastatin_in_holdout_flag_is_true():
+    """Direct guard on the corrected data defect (rdkit-free, always runs)."""
+    for path in _MMPK:
+        for r in _rows(path):
+            if r["name"].strip().lower() == "pravastatin":
+                assert r["in_holdout"].strip().lower() == "true", (
+                    f"{path.name}: pravastatin is a holdout drug; its in_holdout "
+                    f"flag must be True (got {r['in_holdout']!r})"
+                )
+
+
+def test_no_holdout_drug_survives_mmpk_filters():
+    """Replicate load_mmpk_data's effective (in_holdout OR InChIKey-14) filter
+    and assert no holdout drug reaches the ML Cmax training set."""
+    pytest.importorskip("rdkit")
+    from rdkit import Chem, RDLogger
+    from rdkit.Chem.inchi import InchiToInchiKey, MolToInchi
+
+    RDLogger.DisableLog("rdApp.*")
+
+    def ik14(smiles: str | None) -> str | None:
+        if not smiles:
+            return None
+        mol = Chem.MolFromSmiles(smiles)
+        if mol is None:
+            return None
+        inchi = MolToInchi(mol)
+        if not inchi:
+            return None
+        key = InchiToInchiKey(inchi)
+        return key[:14] if key else None
+
+    clinical = json.loads(
+        (ROOT / "data/reference/clinical_pk.json").read_text()
+    ).get("drugs", {})
+    ref_names = _HOLDOUT.get("holdout", []) + _HOLDOUT.get("train", [])
+    ho_ik = set()
+    for n in ref_names:
+        e = clinical.get(n) or clinical.get(n.replace(" ", "_"))
+        if e and e.get("smiles"):
+            k = ik14(e["smiles"])
+            if k:
+                ho_ik.add(k)
+
+    leaks: dict[str, set[str]] = {}
+    for path in _MMPK:
+        for r in _rows(path):
+            if str(r.get("in_holdout", "")).strip().lower() == "true":
+                continue
+            try:
+                if float(r.get("cmax_mg_L", 0)) <= 0:
+                    continue
+            except (TypeError, ValueError):
+                continue
+            k = ik14(r.get("canon_smiles"))
+            if k is None or k in ho_ik:
+                continue
+            name = str(r.get("name", "")).strip().lower()
+            if name in _HOLDOUT_NAMES:
+                leaks.setdefault(path.name, set()).add(name)
+
+    assert not leaks, f"holdout drugs leaking into MMPK training: {leaks}"

--- a/tests/unit/test_rhs_jax_unsupported_flux.py
+++ b/tests/unit/test_rhs_jax_unsupported_flux.py
@@ -1,0 +1,55 @@
+"""Audit follow-up: the JAX RHS must not silently drop unsupported flux types.
+
+``ProdrugActivationFluxSpec`` and ``OneCompartmentEliminationFluxSpec`` have no
+branch in ``make_jax_rhs``'s isinstance chain. Before the
+``_unsupported_flux_specs`` guard they fell through the build loop silently, so a
+graph with a prodrug-activation or active-metabolite edge would have that flux
+omitted from the JAX RHS with no error (the SciPy backend handles them
+correctly). These tests pin a loud failure instead of silent corruption.
+
+The guard is pure Python (no JAX import) so it runs even though JAX is optional
+and absent from ``requirements-lock.txt``.
+"""
+from __future__ import annotations
+
+from sisyphus.engine.flux import (
+    FlowFluxSpec,
+    OneCompartmentEliminationFluxSpec,
+    ProdrugActivationFluxSpec,
+)
+from sisyphus.engine.rhs_jax import _unsupported_flux_specs
+
+
+def _prodrug() -> ProdrugActivationFluxSpec:
+    return ProdrugActivationFluxSpec(
+        0, 0, 1, "parent", "active", frozenset({"CYP3A4"}), 1.0
+    )
+
+
+def _one_compartment() -> OneCompartmentEliminationFluxSpec:
+    return OneCompartmentEliminationFluxSpec(0, 0, 1, "active", "sink")
+
+
+def test_flags_prodrug_activation():
+    spec = _prodrug()
+    assert _unsupported_flux_specs([spec]) == [spec]
+
+
+def test_flags_one_compartment_elimination():
+    spec = _one_compartment()
+    assert _unsupported_flux_specs([spec]) == [spec]
+
+
+def test_supported_flux_not_flagged():
+    flow = FlowFluxSpec(0, 0, 1, "a", "b")
+    assert _unsupported_flux_specs([flow]) == []
+
+
+def test_mixed_returns_only_unsupported():
+    flow = FlowFluxSpec(0, 0, 1, "a", "b")
+    prod = _prodrug()
+    one = _one_compartment()
+    out = _unsupported_flux_specs([flow, prod, one])
+    assert flow not in out
+    assert prod in out
+    assert one in out


### PR DESCRIPTION
## Summary

Two hardening fixes surfaced by a full-codebase completeness audit (29-agent adversarial workflow), plus the experiment-log entry. **No metric change** — neither fix touches the prediction/benchmark path or model artifacts; the headline cache stays Meta **2.69825 / N=79**.

> A third fix from the audit (reconciling the stale CLAUDE.md headline 2.772/N=81 → 2.698/N=79) is **not** in this PR: `CLAUDE.md` is git-untracked (`9006cf9`, local-only Claude context), so it was corrected as a local edit.

## Fix — JAX RHS rejects unsupported flux types instead of silent drop (`49d9f69`)

`ProdrugActivationFluxSpec` and `OneCompartmentEliminationFluxSpec` had no branch in `make_jax_rhs`'s isinstance chain and no terminal `else`, so a graph with a prodrug-activation or active-metabolite edge would have that flux **silently omitted** from the JAX RHS (the SciPy backend handles them correctly). Added a pure-Python `_unsupported_flux_specs()` guard that raises `NotImplementedError` before the build loop. The guard imports no JAX, so the "no silent drop" invariant is unit-tested even though JAX is optional and absent from `requirements-lock.txt`. Dead path today (no production caller uses `backend="jax"`); this prevents a latent correctness landmine.

## Fix — close pravastatin holdout→MMPK training leak; guard invariant #5 (`c957507`)

Pravastatin is the **only** holdout drug (1/107, verified by replicating the two-filter logic) that survives **both** filters in `ml_cmax_improvement.load_mmpk_data`: it has `in_holdout=False` rows **and** its MMPK `canon_smiles` InChIKey-14 (`TUZYXOIXSAXUGO`) differs in connectivity from its clinical_pk SMILES (`GOSGZXISMCZCDW`), so the `ho_ik` filter misses it too. The other ~70 holdout drugs in the corpus are correctly excluded by the InChIKey filter.

- Correct the `in_holdout` flag (`False`→`True`) on pravastatin's 3 rows in both `mmpk_expanded_{full,v2}.csv` — the universal first-line filter every consumer respects.
- Add `load_holdout_names()` + a name-based exclusion to `load_mmpk_data` (defense-in-depth, robust to SMILES-representation drift; mirrors `build_n50_exclusion.py`'s name policy).
- Add `tests/regression/test_mmpk_holdout_leak.py` pinning invariant #5.

**Severity note (corrected from the audit):** the audit framed this as a "live leak in the shipped numbers" — that is **overstated**. The shipped `xgboost_cmax.json` (`v3_clean`, 2026-04-04) was trained on Omega's `mmpk_clean.csv` with its own N=107 3-key exclusion, **not** via this loader (which saves no model). So this is forward-looking data/loader hardening; the current 2.698 headline is unaffected.

## Test plan

- `pytest tests/unit tests/regression` → **776 passed, 22 skipped, 0 failed**
- `ruff check src tests` → clean
- Effective two-filter leak scan over both MMPK CSVs → **0 holdout survivors** (was 1: pravastatin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
