### PR TITLE
chore: B-12 CI Node 24 bump + repo/doc hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
           cache: pip

--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,6 @@ docs/_internal/
 # Manuscript drafts (local-only; binary, frequently revised — not version-tracked)
 Sisyphus_Preprint_*.docx
 Sisyphus_Preprint_*.pdf
+
+# Personal/admin documents (user-managed, never part of the PBPK codebase — 2026-05-31)
+JaeMinYoon_*

--- a/docs/claude/diagnosis.md
+++ b/docs/claude/diagnosis.md
@@ -1,12 +1,12 @@
 ---
-last_updated: 2026-04-20
+last_updated: 2026-05-31
 parent: ../../CLAUDE.md
 charter: Why Sisyphus's Cmax accuracy ceiling exists, what broke it, and which paths remain open
 ---
 
 # Accuracy Ceiling Diagnosis
 
-**Short version:** Meta AAFE 2.695 (4-track, post-merge) is the ceiling under the current architecture. The ceiling is a combined **CLint target-noise floor** (R²≈0.24 is intrinsic, not engineering-limited) + **pipeline error-cancellation** (the 4 tracks are co-calibrated on a specific error profile; partial replacements destroy the balance). VDss analytical 4th track proved that **orthogonal** tracks can still be added, so the ceiling is not absolute — but "orthogonal" now has an empirical test (error decorrelation with existing tracks) that must precede any track proposal.
+**Short version:** Meta AAFE 2.698 (4-track; was 2.695 at 2026-04-20 — the 2.695→2.698 drift is numerics-stack + metric-neutral UGT/prodrug cycles per [CLAUDE.md](../../CLAUDE.md), the qualitative ceiling model is unchanged) is the ceiling under the current architecture. The ceiling is a combined **CLint target-noise floor** (R²≈0.24 is intrinsic, not engineering-limited) + **pipeline error-cancellation** (the 4 tracks are co-calibrated on a specific error profile; partial replacements destroy the balance). VDss analytical 4th track proved that **orthogonal** tracks can still be added, so the ceiling is not absolute — but "orthogonal" now has an empirical test (error decorrelation with existing tracks) that must precede any track proposal.
 
 Before proposing any accuracy improvement, read [dead-ends.md](./dead-ends.md) first — 40 enumerated attempts are documented. Most new proposals that "haven't been tried" are variants of something already reverted.
 


### PR DESCRIPTION
Repo hardening cluster (no `src/`/`data/` changes — holdout cache and headline are untouched; Meta AAFE stays 2.698).

## Commits
1. **chore(gitignore): ignore `JaeMinYoon_*` personal documents** — three untracked personal FDA-essay drafts (1 `.pdf` + 2 `.docx`) sat in the repo root, uncaught by the `Sisyphus_Preprint_*` manuscript rule. One stray `git add -A` would have committed a personal admin doc into the public PBPK repo. Broad `JaeMinYoon_*` pattern blocks that.
2. **ci: bump `checkout@v4→v6` + `setup-python@v5→v6` for Node 24 (B-12)** — GitHub runners force JS actions to Node 24 on **2026-06-02** and remove the Node 20 binary on **2026-09-16**. `checkout@v4`/`setup-python@v5` run on Node 20. Verified via `gh api` that the current majors `checkout@v6` (v6.0.2) and `setup-python@v6` (v6.2.0) declare `using: node24`. Float-on-major matches the existing pin convention.
3. **docs(diagnosis): refresh stale ceiling figure 2.695 → 2.698** — `diagnosis.md` (last_updated 2026-04-20) still stated the ceiling as Meta 2.695; live cache + CLAUDE.md headline are 2.698. Refreshed the §0 figure + `last_updated`, noting the 2.695→2.698 lineage is numerics-stack + metric-neutral UGT/prodrug cycles (qualitative ceiling unchanged). Historical VDss baseline (2.808→2.695, 2026-04-10) left intact as a dated experiment result.

## Verification
- `ruff check src tests` → all checks passed
- Working tree clean; diff limited to the 3 files above
- Node-24 action majors confirmed authoritatively via `gh api repos/<action>/contents/action.yml` (`using: node24`)