### PR TITLE
chore: ignore manuscript/preprint/FDA-essay and binary documents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,9 +75,22 @@ CLAUDE.md
 # readers don't need the day-to-day scratchpad (untracked by user request 2026-05-30).
 docs/_internal/
 
-# Manuscript drafts (local-only; binary, frequently revised — not version-tracked)
+# Manuscript / preprint / FDA-essay drafts and any binary document (local-only;
+# binary, frequently revised — not version-tracked). The repo tracks ZERO binary
+# documents (verified 2026-06-02), so these formats are ignored everywhere. To
+# track a specific one, add a `!path/to/file.pdf` exception below this block.
+*.docx
+*.doc
+*.pdf
+*.odt
+*.rtf
+# (legacy explicit globs retained for clarity — now subsumed by the rules above)
 Sisyphus_Preprint_*.docx
 Sisyphus_Preprint_*.pdf
+# Manuscript text artifacts that aren't binary (e.g. plaintext abstract). Targeted
+# by name so legit tracked docs like Sisyphus_Design_v4.md are NOT shadowed.
+Sisyphus_abstract*
+Sisyphus_Preprint_*.txt
 
 # Personal/admin documents (user-managed, never part of the PBPK codebase — 2026-05-31)
 JaeMinYoon_*


### PR DESCRIPTION
## What
Broaden `.gitignore` so local-only manuscript artifacts never get committed:

- **Binary documents repo-wide:** `*.docx`, `*.doc`, `*.pdf`, `*.odt`, `*.rtf`
- **Non-binary manuscript text:** `Sisyphus_abstract*`, `Sisyphus_Preprint_*.txt`
- Prior name-specific globs (`Sisyphus_Preprint_*.docx/.pdf`, `JaeMinYoon_*`) retained for clarity; now subsumed.

## Why
The repo root accumulates preprint drafts (`Sisyphus_Preprint_v9/v10/bioRxiv.*`), the FDA essay (`JaeMinYoon_FDA_Essay_*`), and a plaintext abstract. These are frequently-revised binaries managed by the author, not part of the PBPK codebase. The previous rules were name-specific and missed the plaintext abstract + any differently-named future draft.

## Safety
- Verified **zero binary documents are tracked** (`git ls-files -- '*.pdf' '*.docx' …` empty), so the repo-wide rule orphans nothing.
- The legit tracked design doc `Sisyphus_Design_v4.md` is **intentionally not shadowed** (targeted patterns used instead of a broad `Sisyphus_*`).
- Markdown docs (README/DESIGN/AGENTS/CHANGELOG) and `requirements-lock.txt` unaffected — `*.md`/`*.txt` are not blanket-ignored.
- All 8 existing documents + the abstract confirmed ignored via `git check-ignore`.

Single-file change (`.gitignore`).