### PR TITLE
Engine-audit follow-ups: extended-ECM fu_correction contract + README validation reconcile

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ y0[compiled.state_index[drug.administration_node]] = drug.dose_mg
 result = solve(compiled, params, y0, t_span=(0, 24))
 pk = compute_endpoints(result)
 
-print(f"Cmax: {pk.cmax.mean:.4f} mg/L")  # 0.0069 mg/L (matches Omega ±0.5%)
+print(f"Cmax: {pk.cmax.mean:.4f} mg/L")  # ~0.0028 mg/L (post FLUX-1 + RBP-2; see Validation)
 ```
 
 ### Monte Carlo uncertainty
@@ -253,8 +253,8 @@ from sisyphus.engine.uncertainty import UncertaintyEngine
 ue = UncertaintyEngine()
 mc = ue.propagate_fast(compiled, graph, drug, n_samples=1000)
 
-print(mc.pk.cmax)                # Distribution(mean≈1.18, cv≈0.3)
-print(mc.cmax_90ci)              # (0.57, 1.59) mg/L
+print(mc.pk.cmax)                # Distribution(mean≈0.0030, cv≈0.22)
+print(mc.cmax_90ci)              # (0.0018, 0.0040) mg/L
 print(len(mc.cmax_samples))      # 1000 individual realizations
 ```
 
@@ -271,7 +271,7 @@ After both fixes, only **caffeine** (R<sub>B:P</sub>=1, low-extraction) remains 
 
 | Drug | Dose | Sisyphus C<sub>max</sub> (mg/L) | Omega C<sub>max</sub> (mg/L) | Basis |
 |------|:----:|:------------:|:----------:|:------|
-| Caffeine | 100 mg PO | 1.7139 | 1.7139 | **Omega parity** — R<sub>B:P</sub>=1, low-extraction; invariant to both fixes (engine reproduces within the &plusmn;5% gate) |
+| Caffeine | 100 mg PO | 1.6910 | 1.7139 | **Omega parity** — R<sub>B:P</sub>=1, low-extraction; invariant to both fixes (1.3% &lt; &plusmn;5% gate, macOS-stack drift) |
 | Midazolam | 2 mg PO | 0.002800 | 0.006943 | Sisyphus snapshot — FLUX-1 + RBP-2 (R<sub>B:P</sub> 0.66) |
 | Warfarin | 10 mg PO | 0.343133 | 0.4922 | Sisyphus snapshot — RBP-2 (R<sub>B:P</sub> 0.58); FLUX-1 no-op (low-extraction) |
 | Propranolol | 80 mg PO | 0.059875 | 0.1355 | Sisyphus snapshot — FLUX-1 + RBP-2 (R<sub>B:P</sub> 0.81) |

--- a/README.md
+++ b/README.md
@@ -260,18 +260,23 @@ print(len(mc.cmax_samples))      # 1000 individual realizations
 
 ## Validation
 
-### Engine validation against Omega PBPK
+### Engine validation: Omega parity and post-correction snapshots
 
-Four drugs with known compound parameters were simulated and compared against the [Omega PBPK](https://github.com/jam-sudo/Omega) ODE engine (35-state hardcoded model):
+Four drugs with known compound parameters are simulated end-to-end (YAML &rarr; BodyGraph &rarr; compile &rarr; solve &rarr; C<sub>max</sub>). They originally matched the [Omega PBPK](https://github.com/jam-sudo/Omega) ODE engine (35-state hardcoded model) to within ~0.5% — but Omega *shared* two physiological bugs that Sisyphus has since corrected, so cross-engine parity is no longer the right oracle for three of the four:
 
-| Drug | Dose | Sisyphus C<sub>max</sub> (mg/L) | Omega C<sub>max</sub> (mg/L) | Relative error |
-|------|:----:|:------------:|:----------:|:-----:|
-| Midazolam | 2 mg PO | 0.006911 | 0.006943 | 0.5% |
-| Caffeine | 100 mg PO | 1.7151 | 1.7139 | 0.1% |
-| Warfarin | 10 mg PO | 0.4917 | 0.4922 | 0.1% |
-| Propranolol | 80 mg PO | 0.1353 | 0.1355 | 0.1% |
+- **FLUX-1** (2026-06-03): a flow-limitation double-count that capped hepatic/gut extraction at E&rarr;0.5. Moves high-extraction drugs (midazolam, propranolol).
+- **RBP-2** (2026-06-04): a blood:plasma concentration-basis correction. Moves any drug with R<sub>B:P</sub> &ne; 1 (midazolam 0.66, warfarin 0.58, propranolol 0.81).
 
-Mass balance error &lt; 10<sup>&minus;12</sup> for all simulations.
+After both fixes, only **caffeine** (R<sub>B:P</sub>=1, low-extraction) remains a true cross-engine Omega-parity check. The other three are now **Sisyphus self-consistency regression snapshots** — their divergence from Omega *is* the correctness fix, not an error. Values are pinned in `tests/integration/test_engine_validation.py` (&plusmn;5% gate; the targets carry documented macOS&harr;CI numerics-stack drift).
+
+| Drug | Dose | Sisyphus C<sub>max</sub> (mg/L) | Omega C<sub>max</sub> (mg/L) | Basis |
+|------|:----:|:------------:|:----------:|:------|
+| Caffeine | 100 mg PO | 1.7139 | 1.7139 | **Omega parity** — R<sub>B:P</sub>=1, low-extraction; invariant to both fixes (engine reproduces within the &plusmn;5% gate) |
+| Midazolam | 2 mg PO | 0.002800 | 0.006943 | Sisyphus snapshot — FLUX-1 + RBP-2 (R<sub>B:P</sub> 0.66) |
+| Warfarin | 10 mg PO | 0.343133 | 0.4922 | Sisyphus snapshot — RBP-2 (R<sub>B:P</sub> 0.58); FLUX-1 no-op (low-extraction) |
+| Propranolol | 80 mg PO | 0.059875 | 0.1355 | Sisyphus snapshot — FLUX-1 + RBP-2 (R<sub>B:P</sub> 0.81) |
+
+Mass balance error &lt; 10<sup>&minus;12</sup> for all simulations. **Lesson:** Omega parity is *not* a sufficient correctness oracle — both shared bugs survived for as long as they did precisely because parity held.
 
 ### Holdout benchmark (SMILES &rarr; C<sub>max</sub>)
 

--- a/data/physiology/reference_man.yaml
+++ b/data/physiology/reference_man.yaml
@@ -78,7 +78,7 @@ nodes:
       # as a clean consequence. Spec 2026-06-04-oatp-ecm-reanchor-design.md.
       OATP1B1: {mean: 1.3e5, cv: 0.484}
     ivive_scaling: 0.00006   # 60/1e6: converts uL/min -> L/h (MPPGL * organ_wt already in abundance)
-    fu_correction_applicable: 1.0   # B-11: hepatic intracellular fu correction is applied at this node by ClearanceFlux + ProdrugActivationFlux
+    fu_correction_applicable: 1.0   # B-11: fu_inc/fu_plasma correction applies to well_stirred/parallel_tube ClearanceFlux + ProdrugActivationFlux at this node. This node's clearance edge below uses model:extended (ECM), which models hepatic uptake explicitly and intentionally does NOT apply it (would double-count) — so here the flag is honored only by ProdrugActivation (e.g. clopidogrel). pipeline.predict warns on a curated non-1.0 value.
 
   - name: spleen
     type: organ

--- a/src/sisyphus/engine/flux.py
+++ b/src/sisyphus/engine/flux.py
@@ -175,11 +175,22 @@ class ClearanceFluxSpec(FluxSpec):
     """Hepatic / renal clearance flux. Four models supported:
 
     - ``well_stirred``  — classical WS with organ-level CLint (default)
-    - ``parallel_tube`` — PT exponential extraction approximation
+    - ``parallel_tube`` — collapses to the well_stirred intrinsic sink in a
+      single well-mixed compartment (a true axial-gradient parallel-tube model
+      is not representable here; not wired in the reference physiology)
     - ``gfr_filtration`` — renal filtration (``CL_renal × C_plasma``)
     - ``extended``      — ECM: QSSA-closed hepatocyte with active + passive
       uptake, passive efflux, metabolism, biliary clearance. See
       ``docs/superpowers/specs/2026-04-20-oatp-ecm-hepatic-clearance-design.md``.
+
+    Hepatic fu correction (B-11): at a node flagged ``fu_correction_applicable``,
+    ``well_stirred`` and ``parallel_tube`` replace ``fup`` with
+    ``fup × fu_correction_liver`` (an empirical fu_inc/fu_plasma uptake
+    correction). ``extended`` and ``gfr_filtration`` intentionally do NOT — the
+    ECM models concentrative hepatic uptake explicitly (PS_active/PS_inf/PS_eff)
+    so the WS-style factor would double-count it, and GFR is a plasma sink with
+    no uptake term. The production liver edge is ``extended``; pipeline.predict
+    warns if a curated non-1.0 value lands on such an edge.
 
     Well-stirred model (FLUX-1: intrinsic clearance on the compartment outlet)::
 
@@ -338,6 +349,13 @@ class ClearanceFluxSpec(FluxSpec):
             cl_int_h = cl_int_metab + cl_int_bile
 
             fup = params.drug_param("fup")
+            # NOTE: the extended ECM intentionally does NOT apply the B-11
+            # fu_correction_liver here (unlike well_stirred/parallel_tube). It is
+            # an empirical fu_inc/fu_plasma factor for concentrative hepatic
+            # uptake, which the ECM already models mechanistically via
+            # PS_active/PS_inf/PS_eff — applying it on top would double-count.
+            # pipeline.predict warns if a non-1.0 value is curated for a drug
+            # whose flagged node clears via this model.
 
             # FLUX-1: intrinsic hepatic clearance (flow-unlimited). At QSSA the
             # hepatocyte removal per unit blood concentration is

--- a/src/sisyphus/pipeline/predict.py
+++ b/src/sisyphus/pipeline/predict.py
@@ -171,6 +171,54 @@ def _apply_measured_f(
 # src/sisyphus/pipeline/predict.py -> ../../../../data/physiology
 _PHYSIOLOGY_DIR = Path(__file__).resolve().parent.parent.parent.parent / "data" / "physiology"
 
+# Clearance models that model hepatic uptake mechanistically and therefore do
+# NOT apply the B-11 well_stirred/parallel_tube fu_inc/fu_plasma correction
+# (applying it would double-count the explicit PS uptake / GFR plasma sink).
+_FU_CORRECTION_DROP_MODELS = frozenset({"extended", "gfr_filtration"})
+
+
+def _fu_correction_drop_warning(graph, fu_correction_liver_mean: float) -> str | None:
+    """Warn when a non-identity hepatic fu_correction lands on a flagged node
+    whose clearance edge uses a model that does not apply it.
+
+    B-11 wired ``fu_correction_liver`` into the well_stirred / parallel_tube
+    clearance models and ProdrugActivation. The production liver clearance edge,
+    however, uses the extended ECM, which models concentrative hepatic uptake
+    explicitly (PS_active / PS_inf / PS_eff) and therefore intentionally drops
+    the WS-style ``fu_inc/fu_plasma`` factor — applying it would double-count
+    that uptake. Without this warning a future curated value would silently
+    no-op on the liver and pass every test. Returns ``None`` (no warning) for
+    the default ``1.0``, so the current headline path is bit-identical.
+    """
+    if fu_correction_liver_mean == 1.0:
+        return None
+    from sisyphus.graph.types import ClearanceEdge
+
+    flagged = {
+        name for name, node in graph.nodes.items()
+        if node.fu_correction_applicable > 0
+    }
+    dropped = sorted({
+        (edge.source, edge.model)
+        for edge in graph.edges
+        if isinstance(edge, ClearanceEdge)
+        and edge.source in flagged
+        and edge.model in _FU_CORRECTION_DROP_MODELS
+    })
+    if not dropped:
+        return None
+    nodes = sorted({src for src, _ in dropped})
+    models = sorted({model for _, model in dropped})
+    return (
+        f"fu_correction_liver={fu_correction_liver_mean:.3g} is not applied at "
+        f"clearance node(s) {nodes} (model(s): {models}): these models capture "
+        f"hepatic uptake mechanistically and intentionally drop the "
+        f"well_stirred/parallel_tube fu correction (applying it would "
+        f"double-count). It still applies to well_stirred/parallel_tube "
+        f"clearance and ProdrugActivation; to model enhanced hepatic uptake set "
+        f"the ECM transporter params (ps_active jmax/km)."
+    )
+
 
 def predict(
     smiles: str,
@@ -440,6 +488,14 @@ def predict(
 
         from sisyphus.graph.builder import augment_for_active_species
         graph = augment_for_active_species(graph, drug)
+
+        # B-11 contract guard: surface a warning if a curated (non-1.0)
+        # fu_correction_liver lands on a flagged node whose clearance model
+        # drops it (extended ECM / gfr). No-op today — every registry value is
+        # 1.0 — so the headline path stays bit-identical.
+        _fu_warn = _fu_correction_drop_warning(graph, drug.fu_correction_liver.mean)
+        if _fu_warn:
+            warnings_list.append(_fu_warn)
 
         compiler = ODECompiler()
         compiled = compiler.compile(graph)

--- a/src/sisyphus/pipeline/predict.py
+++ b/src/sisyphus/pipeline/predict.py
@@ -186,9 +186,11 @@ def _fu_correction_drop_warning(graph, fu_correction_liver_mean: float) -> str |
     however, uses the extended ECM, which models concentrative hepatic uptake
     explicitly (PS_active / PS_inf / PS_eff) and therefore intentionally drops
     the WS-style ``fu_inc/fu_plasma`` factor — applying it would double-count
-    that uptake. Without this warning a future curated value would silently
-    no-op on the liver and pass every test. Returns ``None`` (no warning) for
-    the default ``1.0``, so the current headline path is bit-identical.
+    that uptake. Without this warning a curated value would silently no-op on
+    that clearance edge (for a non-prodrug liver, its entire clearance
+    contribution; a prodrug's ProdrugActivation edge at the same node still
+    applies it) and pass every test. Returns ``None`` (no warning) for the
+    default ``1.0``, so the current headline path is bit-identical.
     """
     if fu_correction_liver_mean == 1.0:
         return None
@@ -210,13 +212,14 @@ def _fu_correction_drop_warning(graph, fu_correction_liver_mean: float) -> str |
     nodes = sorted({src for src, _ in dropped})
     models = sorted({model for _, model in dropped})
     return (
-        f"fu_correction_liver={fu_correction_liver_mean:.3g} is not applied at "
-        f"clearance node(s) {nodes} (model(s): {models}): these models capture "
-        f"hepatic uptake mechanistically and intentionally drop the "
-        f"well_stirred/parallel_tube fu correction (applying it would "
-        f"double-count). It still applies to well_stirred/parallel_tube "
-        f"clearance and ProdrugActivation; to model enhanced hepatic uptake set "
-        f"the ECM transporter params (ps_active jmax/km)."
+        f"fu_correction_liver={fu_correction_liver_mean:.3g} is dropped by the "
+        f"clearance-edge model at node(s) {nodes} (model(s): {models}): these "
+        f"models do not apply the well_stirred/parallel_tube fu correction "
+        f"(the extended ECM models hepatic uptake explicitly, so it would "
+        f"double-count; gfr_filtration is a plasma sink with no fup term). It "
+        f"is still applied by any well_stirred/parallel_tube clearance or "
+        f"ProdrugActivation edge at the same node; for an extended-ECM node, "
+        f"model enhanced uptake via the transporter params (ps_active jmax/km)."
     )
 
 

--- a/tests/integration/test_engine_validation.py
+++ b/tests/integration/test_engine_validation.py
@@ -5,12 +5,14 @@ Runs 4 validation drugs through the complete pipeline:
     YAML -> BodyGraph -> compile -> solve -> Cmax
 and compares against reference deterministic ODE Cmax within +/-5%.
 
-caffeine/warfarin are LOW-extraction and pinned to Omega's predecessor values.
-midazolam/propranolol are HIGH-extraction: the FLUX-1 fix (2026-06-03) corrected
-a flow-limitation double-count that Omega shared, so their targets are now
-FLUX-1-corrected Sisyphus snapshots, not independent Omega values (see
-OMEGA_TARGETS comment). The test thus mixes 2 cross-engine parity checks with 2
-self-consistency snapshots; all 4 still serve as drift regressions.
+Only caffeine (R_B:P=1, low-extraction) remains an Omega cross-engine parity
+check. midazolam/propranolol (high-extraction) moved off Omega via the FLUX-1
+flow-limitation fix (2026-06-03), and midazolam/warfarin/propranolol (R_B:P!=1)
+moved via the RBP-2 blood:plasma basis fix (2026-06-04) — Omega shared both
+bugs, so their targets are now post-correction Sisyphus snapshots, not
+independent Omega values (see OMEGA_TARGETS comment). The test thus mixes 1
+cross-engine parity check (caffeine) with 3 self-consistency snapshots; all 4
+still serve as drift regressions.
 """
 
 from pathlib import Path

--- a/tests/unit/test_flux_fu_correction_integration.py
+++ b/tests/unit/test_flux_fu_correction_integration.py
@@ -471,7 +471,7 @@ def test_predict_warns_when_fu_correction_dropped_at_extended_node(monkeypatch):
     result = predict(caffeine, dose_mg=100.0, route="oral")
 
     assert any(
-        "fu_correction_liver" in w and "not applied" in w for w in result.warnings
+        "fu_correction_liver" in w and "dropped" in w for w in result.warnings
     ), f"expected dropped-fu_correction warning; got {result.warnings!r}"
 
 
@@ -490,5 +490,5 @@ def test_predict_no_fu_correction_warning_at_default(monkeypatch):
     result = predict(caffeine, dose_mg=100.0, route="oral")
 
     assert not any(
-        "fu_correction_liver" in w and "not applied" in w for w in result.warnings
+        "fu_correction_liver" in w and "dropped" in w for w in result.warnings
     ), f"no warning expected at default 1.0; got {result.warnings!r}"

--- a/tests/unit/test_flux_fu_correction_integration.py
+++ b/tests/unit/test_flux_fu_correction_integration.py
@@ -7,8 +7,16 @@ exactly the code paths Task 6 modifies, independent of which
 production drug routes through which flux type.
 
 Identity-blind random-rename invariance is verified in Task 8.
-ProdrugActivationFluxSpec gating is verified in Task 7. ECM
-(extended) branch is out of B-11 scope.
+ProdrugActivationFluxSpec gating is verified in Task 7. The ECM
+(extended) clearance model intentionally does NOT apply the correction:
+it models concentrative hepatic uptake explicitly (PS_active/PS_inf/
+PS_eff), so multiplying fup by the WS-style fu_inc/fu_plasma factor
+would double-count that uptake. That decision is pinned by
+``test_extended_clearance_ignores_fu_correction_by_design`` and the
+silent-no-op trap (the production liver clears via ``extended``) is
+closed by a runtime warning from ``pipeline.predict`` — see
+``test_predict_warns_when_fu_correction_dropped_at_extended_node``
+(2026-06-05 contract fix).
 """
 
 from __future__ import annotations
@@ -159,9 +167,14 @@ def test_well_stirred_fu_correction_amplifies_clearance_when_flagged():
 
 
 def test_parallel_tube_fu_correction_amplifies_clearance_when_flagged():
-    """parallel_tube branch: same gating behavior with the PT formula
-        CL = Q * (1 - exp(-fup_eff * CLint / Q))
-    Verifies the Task 6 patch is applied to the PT branch too.
+    """parallel_tube branch: same fu_correction gating as well_stirred.
+
+    Post-FLUX-1 the parallel_tube branch collapses to the intrinsic
+    clearance ``fup_eff * CLint`` applied to ``c_out`` — a single
+    well-mixed compartment cannot represent the axial gradient a true
+    parallel-tube ``CL = Q*(1 - exp(-fup_eff*CLint/Q))`` requires — so the
+    assertion below pins that collapsed form. This still verifies the
+    Task 6 fu correction is applied to the PT branch.
     """
     rate_baseline = _eval_clearance_rate(
         model="parallel_tube",
@@ -399,3 +412,83 @@ def test_prodrug_flux_applies_correction_at_flagged_node_via_predict(monkeypatch
         f"ProdrugActivationFlux at liver must respect fu_correction_liver; "
         f"fu_corr=5: {cmax_high:.4f}, fu_corr=1: {cmax_low:.4f}"
     )
+
+
+def test_extended_clearance_ignores_fu_correction_by_design():
+    """The extended (ECM) clearance model intentionally does NOT apply
+    fu_correction_liver, unlike well_stirred / parallel_tube.
+
+    fu_correction_liver is fu_inc/fu_plasma — an empirical lumped correction
+    for albumin-facilitated / transporter-mediated *concentrative hepatic
+    uptake* (B-11 spec §2). The ECM models exactly that uptake mechanistically
+    (PS_active/PS_inf/PS_eff), so multiplying fup by the WS-style factor on top
+    would double-count. This test PINS that decision: a flagged node whose
+    clearance edge is ``extended`` produces a bit-identical rate whether
+    fu_correction_liver is 1.0 or 5.0. The PRODUCTION liver clearance edge is
+    ``extended`` (reference_man.yaml), so this is the behavior on the real
+    headline path. The matching contract guard — a runtime warning when a
+    non-1.0 value is curated — lives in pipeline.predict.
+    """
+    rate_baseline = _eval_clearance_rate(
+        model="extended",
+        fu_correction_applicable=1.0,
+        fu_correction_liver=1.0,
+    )
+    rate_corrected = _eval_clearance_rate(
+        model="extended",
+        fu_correction_applicable=1.0,
+        fu_correction_liver=5.0,
+    )
+
+    # Sanity: the ECM sink is active (non-zero), else the equality is vacuous.
+    assert rate_baseline > 0.0
+    # fu_correction has NO effect on the extended branch — by design.
+    assert rate_baseline == rate_corrected, (
+        f"extended ECM must ignore fu_correction_liver (would double-count the "
+        f"explicit PS uptake); baseline={rate_baseline!r}, "
+        f"corrected={rate_corrected!r}"
+    )
+
+
+def test_predict_warns_when_fu_correction_dropped_at_extended_node(monkeypatch):
+    """pipeline.predict surfaces a warning when a non-identity
+    fu_correction_liver is curated for a drug whose flagged hepatic node clears
+    via the extended ECM (which drops the correction by design).
+
+    Closes the B-11 'silent no-op' trap: the production liver clearance edge is
+    ``extended``, so without this warning a future curated value would vanish
+    unnoticed and still pass every test. Patches the source-module lookup (the
+    function-local import in ivive.py re-binds on every predict() call).
+    """
+    from sisyphus.pipeline.predict import predict
+
+    caffeine = "CN1C=NC2=C1C(=O)N(C(=O)N2C)C"
+    monkeypatch.setattr(
+        "sisyphus.predict.hepatic_fu_correction.lookup_hepatic_fu_correction",
+        lambda smiles, registry_path=None: Distribution(mean=2.0, cv=0.0),
+        raising=False,
+    )
+    result = predict(caffeine, dose_mg=100.0, route="oral")
+
+    assert any(
+        "fu_correction_liver" in w and "not applied" in w for w in result.warnings
+    ), f"expected dropped-fu_correction warning; got {result.warnings!r}"
+
+
+def test_predict_no_fu_correction_warning_at_default(monkeypatch):
+    """Control: with the default fu_correction_liver=1.0 (every shipped registry
+    value today), NO warning is emitted — so the production headline path is
+    bit-identical (the guard fires only on a curated non-1.0 value)."""
+    from sisyphus.pipeline.predict import predict
+
+    caffeine = "CN1C=NC2=C1C(=O)N(C(=O)N2C)C"
+    monkeypatch.setattr(
+        "sisyphus.predict.hepatic_fu_correction.lookup_hepatic_fu_correction",
+        lambda smiles, registry_path=None: Distribution(mean=1.0, cv=0.0),
+        raising=False,
+    )
+    result = predict(caffeine, dose_mg=100.0, route="oral")
+
+    assert not any(
+        "fu_correction_liver" in w and "not applied" in w for w in result.warnings
+    ), f"no warning expected at default 1.0; got {result.warnings!r}"


### PR DESCRIPTION
## Summary

Two correctness/contract follow-ups from the 2026-06-04 engine-audit meta-review (`docs/engine_audit_review_2026-06-04.md`). Both are **metric-neutral** — the 2.784 headline is bit-identical.

### 1. Extended-ECM `fu_correction` contract (the audit's "most important real issue")

The production liver clearance edge uses `model: extended` (ECM), but B-11's `fu_correction_liver` was wired only into well_stirred / parallel_tube / ProdrugActivation. So the liver YAML comment falsely claimed `ClearanceFlux` applies it, and a future curated value would **silently no-op on the liver and pass all tests**.

Resolution — chose *"don't apply in extended"* over *"implement in extended"*: `fu_correction_liver` is an empirical `fu_inc/fu_plasma` factor for concentrative hepatic uptake, which the ECM already models mechanistically (`PS_active`/`PS_inf`/`PS_eff`) — applying it would **double-count**. Made the decision explicit and closed the silent trap:

- `reference_man.yaml`: corrected the false liver-node comment
- `flux.py`: documented which models apply the correction (and why `extended`/`gfr` don't); fixed the stale `parallel_tube` "exponential extraction" docstring
- `predict.py`: warns when a non-1.0 `fu_correction_liver` lands on a flagged node whose clearance model drops it
- tests: pin "extended ignores fu_correction by design" + predict warning fires at 2.0 / silent at 1.0 (TDD)

### 2. README engine-validation table reconcile

The table still framed all 4 drugs as Omega parity with pre-correction values. After FLUX-1 (flow-limitation) + RBP-2 (blood:plasma basis), 3 of 4 moved (warfarin via RBP-2 alone, FLUX-1 no-op). Reframed as **1 parity check (caffeine) + 3 post-correction Sisyphus snapshots**, updated to the pinned test goldens; fixed the same "2 parity + 2 snapshots" miscount in the `test_engine_validation.py` header docstring.

## Test plan

- `ruff check src tests` — clean
- new + existing fu_correction tests, flux / ecm / active_transport / rbp, `test_engine_validation`, holdout cache-pin — all green locally
- the guard is a no-op at `fu_correction_liver=1.0` (every shipped registry value), so engine Cmax is bit-identical