### PR TITLE
feat(mipd): dose recommendation (target attainment) over the IV steady-state TDM posterior

### DIFF
--- a/docs/superpowers/plans/2026-06-12-mipd-dose-recommendation.md
+++ b/docs/superpowers/plans/2026-06-12-mipd-dose-recommendation.md
@@ -1,0 +1,850 @@
+# MIPD Dose Recommendation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `recommend_dose()` — given an IV regimen, a measured trough, and a clinical target (constraints on trough/Cmax/AUC24), recommend the (dose, interval) maximizing the probability the target is met under the conditioned posterior.
+
+**Architecture:** A new self-contained `src/sisyphus/mipd/dosing.py`. The patient's renal-CL posterior is inferred once via `predict_tdm` (a patient property, regimen-invariant). For each candidate interval τ, one engine re-solve (`build_renal_cl_grid`) yields per-posterior-sample reference exposures; the dose is then solved **analytically** because the engine is linear in dose (LTI) — a max-interval-overlap sweep over the per-sample feasible dose-multiplier ranges. Reuses the forward model verbatim; `engine/`, `predict()`, and `PosteriorPK` are untouched.
+
+**Tech Stack:** Python 3.10+, numpy, frozen dataclasses, pytest. No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-06-12-mipd-dose-recommendation-design.md`
+
+**Conventions to follow** (from the existing `mipd/` modules):
+- `from __future__ import annotations` at the top of every module.
+- Module-level docstring; `logging` not `print`.
+- Frozen dataclasses; type hints on all public signatures.
+- `ruff` line length 100.
+- Commit messages: `type(mipd): description` — NO `Co-Authored-By` / AI trailer (project directive).
+- Reference SMILES used in existing tests: `ATENOLOL = "CC(C)NCC(O)COc1ccc(CC(N)=O)cc1"` (high-fup, renally cleared — the right drug for renal-CL TDM tests).
+
+**Reused APIs (verified — use exactly these signatures):**
+- `sisyphus.mipd.core.Posterior(samples: np.ndarray)` → `.point` (median), `.mean`, `.ci90`.
+- `sisyphus.mipd.tdm.predict_tdm(smiles, regimen, observations, *, covariates=None, renal_prior_cv=1.0, n_samples=20000, n_grid=13, seed=0, kp_method="rodgers_rowland") -> PosteriorPK`. Returns `post.renal_scale: Posterior`, `post.n_eff: float`, `post.warnings: tuple[str,...]`.
+- `sisyphus.mipd.renal_grid.build_renal_cl_grid(smiles, regimen, *, n_grid=13, r_range=(0.2,5.0), renal_factor=1.0, body_weight_kg=None, age_years=None, kp_method="rodgers_rowland", dt_output=0.1) -> RenalCLGrid`.
+- `RenalCLGrid.conc_at(r: np.ndarray, t: float) -> np.ndarray` (raises if `t` outside the grid horizon).
+- `sisyphus.mipd.renal_grid.RenalCLForward(grid).__call__(r) -> {"renal_scale","cmax","auc","conc_at"}`.
+- `sisyphus.mipd.renal_grid._regimen_interval_h(regimen) -> float` (module-private; the orchestrator passes τ explicitly instead — do NOT import it into `dosing.py`).
+- `sisyphus.mipd.clgrid.MeasuredConc(value: float, t: float, cv: float = 0.25)`.
+- `sisyphus.regimen.types.DosingRegimen.iv_infusion(dose_mg, duration_h, interval_h, n_doses)`; `DEFAULT_IV_NODE = "venous_blood"`; events carry `.dose_mg`, `.duration_h`, `.node`; `regimen.last_dose_time_h`.
+- `sisyphus.mipd.covariates.Covariates` → `.renal_factor()`, `.body_weight_kg`, `.age_years`.
+
+---
+
+## File Structure
+
+- **Create** `src/sisyphus/mipd/dosing.py` — all types + the analytic solve + `recommend_dose`. One responsibility: turn a posterior + target into a (dose, interval) recommendation. (mipd/ goes 9→10 `.py` files — within the 20-file ceiling.)
+- **Modify** `src/sisyphus/mipd/__init__.py` — export the new public names.
+- **Create** `tests/unit/test_mipd_dosing.py` — type/validation + analytic-solve unit tests + behavioral integration tests.
+
+Task order: types → analytic solve (pure numpy) → per-interval reference (engine) → orchestrator → exports.
+
+---
+
+### Task 1: Constraint / DoseTarget / CandidateEval / DoseRecommendation types
+
+**Files:**
+- Create: `src/sisyphus/mipd/dosing.py`
+- Test: `tests/unit/test_mipd_dosing.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/unit/test_mipd_dosing.py
+"""Unit + integration tests for mipd.dosing (dose recommendation / target attainment)."""
+import numpy as np
+import pytest
+
+from sisyphus.mipd.clgrid import MeasuredConc
+from sisyphus.mipd.covariates import Covariates
+from sisyphus.mipd.dosing import (
+    CandidateEval,
+    Constraint,
+    DoseRecommendation,
+    DoseTarget,
+    recommend_dose,
+)
+from sisyphus.regimen.types import DosingRegimen
+
+ATENOLOL = "CC(C)NCC(O)COc1ccc(CC(N)=O)cc1"  # high-fup, renally cleared
+
+
+def _iv_regimen():
+    return DosingRegimen.iv_infusion(dose_mg=50.0, duration_h=0.5, interval_h=8.0, n_doses=5)
+
+
+def test_constraint_rejects_unknown_quantity():
+    with pytest.raises(ValueError, match="quantity"):
+        Constraint(quantity="halflife", low=1.0)
+
+
+def test_constraint_rejects_no_bound():
+    with pytest.raises(ValueError, match="at least one"):
+        Constraint(quantity="trough")
+
+
+def test_constraint_rejects_low_above_high():
+    with pytest.raises(ValueError, match="low"):
+        Constraint(quantity="trough", low=5.0, high=2.0)
+
+
+def test_constraint_accepts_one_sided():
+    c = Constraint(quantity="cmax", high=10.0)
+    assert c.low is None and c.high == 10.0
+
+
+def test_dose_target_rejects_empty():
+    with pytest.raises(ValueError, match="at least one constraint"):
+        DoseTarget(constraints=())
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `pytest tests/unit/test_mipd_dosing.py -x -q`
+Expected: FAIL with `ModuleNotFoundError: No module named 'sisyphus.mipd.dosing'`.
+
+- [ ] **Step 3: Implement the types**
+
+```python
+# src/sisyphus/mipd/dosing.py
+"""Dose recommendation (target attainment) over the IV steady-state TDM posterior.
+
+``predict_tdm`` infers the patient's renal-clearance posterior from a measured
+steady-state trough. This module closes the clinical loop: given a target (a set of
+constraints on the steady-state trough, peak Cmax, and/or AUC24), recommend the
+(dose, interval) that maximizes the probability the target is met under that
+posterior.
+
+The engine is **linear in dose** (concentration-independent clearance — no saturable
+Michaelis-Menten in this path), so at a fixed disposition every steady-state exposure
+scales linearly with dose. The dose knob is therefore inverted *analytically* (one
+solve per interval, then a max-interval-overlap sweep over per-sample feasible
+dose-multiplier ranges); only the interval knob (nonlinear accumulation) costs an
+engine re-solve. See docs/superpowers/specs/2026-06-12-mipd-dose-recommendation-design.md.
+"""
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import numpy as np
+
+from sisyphus.mipd.core import Posterior
+
+_QUANTITIES = ("trough", "cmax", "auc24")
+
+
+@dataclass(frozen=True)
+class Constraint:
+    """A bound on one steady-state PK quantity, evaluated under the posterior.
+
+    ``quantity`` is one of ``"trough"`` / ``"cmax"`` / ``"auc24"``. At least one of
+    ``low`` / ``high`` must be set (mg/L for trough/cmax, mg*h/L for auc24).
+    """
+
+    quantity: str
+    low: float | None = None
+    high: float | None = None
+
+    def __post_init__(self) -> None:
+        if self.quantity not in _QUANTITIES:
+            raise ValueError(f"quantity must be one of {_QUANTITIES}, got {self.quantity!r}")
+        if self.low is None and self.high is None:
+            raise ValueError("Constraint needs at least one of low/high")
+        if self.low is not None and self.low < 0:
+            raise ValueError(f"low must be >= 0, got {self.low}")
+        if self.high is not None and self.high <= 0:
+            raise ValueError(f"high must be > 0, got {self.high}")
+        if self.low is not None and self.high is not None and self.low > self.high:
+            raise ValueError(f"low {self.low} > high {self.high}")
+
+
+@dataclass(frozen=True)
+class DoseTarget:
+    """A set of constraints. Attainment = P(ALL constraints satisfied) under the posterior."""
+
+    constraints: tuple[Constraint, ...]
+
+    def __post_init__(self) -> None:
+        if not self.constraints:
+            raise ValueError("DoseTarget needs at least one constraint")
+
+
+@dataclass(frozen=True)
+class CandidateEval:
+    """One (dose, interval) row of the recommendation search — for transparency."""
+
+    dose_mg: float
+    interval_h: float
+    attainment_prob: float
+    trough_median: float
+    cmax_median: float
+    auc24_median: float
+
+
+@dataclass(frozen=True)
+class DoseRecommendation:
+    """The recommended regimen and the exposure posteriors it produces."""
+
+    dose_mg: float
+    interval_h: float
+    attainment_prob: float
+    cmax: Posterior
+    trough: Posterior
+    auc24: Posterior
+    target: DoseTarget
+    candidates: tuple[CandidateEval, ...]
+    renal_scale: Posterior
+    n_eff: float
+    warnings: tuple[str, ...]
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `pytest tests/unit/test_mipd_dosing.py -x -q`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sisyphus/mipd/dosing.py tests/unit/test_mipd_dosing.py
+git commit -m "feat(mipd): dose-recommendation Constraint/DoseTarget/result types"
+```
+
+---
+
+### Task 2: Analytic LTI dose solve (pure numpy)
+
+The core math. Pure numpy over synthetic per-sample arrays — no engine, fast, and **stack-independent** (no floating engine numerics). This is the load-bearing algorithm.
+
+**Files:**
+- Modify: `src/sisyphus/mipd/dosing.py`
+- Test: `tests/unit/test_mipd_dosing.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# append to tests/unit/test_mipd_dosing.py
+from sisyphus.mipd.dosing import (  # noqa: E402  (extend the existing import)
+    _attainment,
+    _center_m,
+    _max_overlap_region,
+    _sample_m_intervals,
+)
+
+
+def test_sample_m_intervals_two_sided_window():
+    # q_ref = 1.0 for all; trough window [2, 4] -> m must be in [2, 4].
+    q_ref = {"trough": np.array([1.0, 1.0, 1.0])}
+    target = DoseTarget((Constraint("trough", low=2.0, high=4.0),))
+    m_lo, m_hi = _sample_m_intervals(q_ref, target)
+    assert np.allclose(m_lo, 2.0)
+    assert np.allclose(m_hi, 4.0)
+
+
+def test_sample_m_intervals_unbounded_sides():
+    q_ref = {"cmax": np.array([2.0, 2.0])}
+    # ceiling only -> m_lo == 0, m_hi == high/q
+    lo, hi = _sample_m_intervals(q_ref, DoseTarget((Constraint("cmax", high=10.0),)))
+    assert np.allclose(lo, 0.0) and np.allclose(hi, 5.0)
+    # floor only -> m_lo == low/q, m_hi == inf
+    lo, hi = _sample_m_intervals(q_ref, DoseTarget((Constraint("cmax", low=4.0),)))
+    assert np.allclose(lo, 2.0) and np.all(np.isinf(hi))
+
+
+def test_max_overlap_region_picks_densest_segment():
+    # intervals: [0,2], [1,3], [1,4]  -> max overlap (3) on [1, 2]
+    m_lo = np.array([0.0, 1.0, 1.0])
+    m_hi = np.array([2.0, 3.0, 4.0])
+    a, b, count = _max_overlap_region(m_lo, m_hi)
+    assert count == 3
+    assert a == pytest.approx(1.0) and b == pytest.approx(2.0)
+
+
+def test_attainment_counts_covering_intervals():
+    m_lo = np.array([0.0, 1.0, 1.0])
+    m_hi = np.array([2.0, 3.0, 4.0])
+    assert _attainment(1.5, m_lo, m_hi) == pytest.approx(1.0)   # all three cover 1.5
+    assert _attainment(3.5, m_lo, m_hi) == pytest.approx(1.0 / 3.0)  # only [1,4]
+
+
+def test_center_m_rules():
+    assert _center_m(2.0, 8.0) == pytest.approx(4.0)        # bounded -> geometric mid sqrt(16)
+    assert _center_m(3.0, math.inf) == pytest.approx(3.0)   # only floors -> smallest (a)
+    assert _center_m(0.0, 5.0) == pytest.approx(5.0)        # only ceilings -> largest (b)
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `pytest tests/unit/test_mipd_dosing.py -k "m_intervals or overlap or attainment or center_m" -q`
+Expected: FAIL with `ImportError` (helpers not defined).
+
+- [ ] **Step 3: Implement the helpers**
+
+```python
+# append to src/sisyphus/mipd/dosing.py
+
+def _sample_m_intervals(
+    q_ref: dict[str, np.ndarray], target: DoseTarget
+) -> tuple[np.ndarray, np.ndarray]:
+    """Per posterior-sample feasible dose-multiplier interval ``[m_lo, m_hi]``.
+
+    Each exposure scales linearly with the dose multiplier ``m`` (LTI). A constraint
+    ``low <= m*q_ref <= high`` becomes ``m in [low/q_ref, high/q_ref]``; intersecting
+    across constraints gives ``[m_lo[i], m_hi[i]]`` per sample (0 / +inf when a side
+    is unbounded).
+    """
+    n = len(next(iter(q_ref.values())))
+    m_lo = np.zeros(n)
+    m_hi = np.full(n, np.inf)
+    for c in target.constraints:
+        q = np.maximum(np.asarray(q_ref[c.quantity], dtype=float), 1e-300)
+        if c.low is not None:
+            m_lo = np.maximum(m_lo, c.low / q)
+        if c.high is not None:
+            m_hi = np.minimum(m_hi, c.high / q)
+    return m_lo, m_hi
+
+
+def _attainment(m: float, m_lo: np.ndarray, m_hi: np.ndarray) -> float:
+    """Fraction of posterior samples whose feasible interval covers dose-multiplier ``m``."""
+    return float(np.mean((m_lo <= m) & (m <= m_hi)))
+
+
+def _max_overlap_region(
+    m_lo: np.ndarray, m_hi: np.ndarray
+) -> tuple[float, float, int]:
+    """Dose-multiplier segment ``[a, b]`` where the most sample-intervals overlap.
+
+    Classic max-interval-overlap sweep. At a tie, a start is ordered before an end so
+    a point shared by ``[., x]`` and ``[x, .]`` counts both (closed intervals). Returns
+    ``(a, b, count)``; ``b`` may be ``inf`` (only-floor constraints). Empty sample
+    intervals (``m_lo > m_hi``) are dropped.
+    """
+    feasible = m_lo <= m_hi
+    los = m_lo[feasible]
+    his = m_hi[feasible]
+    if los.size == 0:
+        return (0.0, 0.0, 0)
+    pts = np.concatenate([los, his])
+    kinds = np.concatenate([np.ones(los.size), -np.ones(his.size)])  # +1 start, -1 end
+    order = np.lexsort((-kinds, pts))  # by point asc; starts (+1) before ends (-1) at ties
+    pts = pts[order]
+    cov = np.cumsum(kinds[order])
+    best_i = int(np.argmax(cov))
+    a = float(pts[best_i])
+    b = float(pts[best_i + 1]) if best_i + 1 < pts.size else a
+    return (a, b, int(cov[best_i]))
+
+
+def _center_m(a: float, b: float) -> float:
+    """Pick the dose multiplier within the max-overlap region ``[a, b]``.
+
+    Bounded window -> geometric midpoint (max margin). Only floors (b == inf) ->
+    smallest dose meeting them (``a``). Only ceilings (a == 0) -> largest dose under
+    them (``b``).
+    """
+    if not math.isfinite(b):
+        return a if a > 0.0 else 1.0
+    if a <= 0.0:
+        return b
+    return math.sqrt(a * b)
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `pytest tests/unit/test_mipd_dosing.py -k "m_intervals or overlap or attainment or center_m" -q`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sisyphus/mipd/dosing.py tests/unit/test_mipd_dosing.py
+git commit -m "feat(mipd): analytic LTI dose solve (max-interval-overlap sweep)"
+```
+
+---
+
+### Task 3: Per-interval reference exposures + LTI exactness (the load-bearing premise)
+
+**Files:**
+- Modify: `src/sisyphus/mipd/dosing.py`
+- Test: `tests/unit/test_mipd_dosing.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# append to tests/unit/test_mipd_dosing.py
+from sisyphus.mipd.dosing import _interval_reference  # noqa: E402
+
+
+def test_lti_exactness_grid_scales_linearly_with_dose():
+    # The whole layer rests on the engine being linear in dose. Doubling the dose must
+    # exactly double steady-state Cmax and AUC at every renal scale. A future saturable
+    # nonlinearity would fail HERE.
+    from sisyphus.mipd.renal_grid import build_renal_cl_grid
+
+    g1 = build_renal_cl_grid(
+        ATENOLOL, DosingRegimen.iv_infusion(50.0, 0.5, 8.0, 5), n_grid=5
+    )
+    g2 = build_renal_cl_grid(
+        ATENOLOL, DosingRegimen.iv_infusion(100.0, 0.5, 8.0, 5), n_grid=5
+    )
+    assert np.allclose(g2.cmax, 2.0 * g1.cmax, rtol=1e-6)
+    assert np.allclose(g2.auc, 2.0 * g1.auc, rtol=1e-6)
+
+
+def test_interval_reference_returns_quantities_at_reference_dose():
+    reg = _iv_regimen()
+    r = np.array([1.0, 1.0, 1.0])
+    q_ref, d_ref = _interval_reference(
+        ATENOLOL, reg, 8.0, r, renal_factor=1.0, body_weight_kg=None,
+        age_years=None, n_grid=5, kp_method="rodgers_rowland",
+    )
+    assert d_ref == 50.0
+    assert set(q_ref) == {"trough", "cmax", "auc24"}
+    for key in q_ref:
+        assert q_ref[key].shape == (3,)
+        assert np.all(q_ref[key] > 0)
+    # trough must equal the grid's own conc at the end of the final interval at r=1.
+    from sisyphus.mipd.renal_grid import build_renal_cl_grid
+
+    g = build_renal_cl_grid(ATENOLOL, reg, n_grid=5)
+    expect = float(g.conc_at(np.array([1.0]), reg.last_dose_time_h + 8.0)[0])
+    assert q_ref["trough"][0] == pytest.approx(expect, rel=1e-9)
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `pytest tests/unit/test_mipd_dosing.py -k "lti or interval_reference" -q`
+Expected: `test_lti_exactness...` PASSES already (it only uses existing code); `test_interval_reference...` FAILS with `ImportError: cannot import name '_interval_reference'`.
+
+- [ ] **Step 3: Implement `_interval_reference`**
+
+```python
+# append to src/sisyphus/mipd/dosing.py
+
+def _interval_reference(
+    smiles: str,
+    regimen,
+    tau: float,
+    r_samples: np.ndarray,
+    *,
+    renal_factor: float,
+    body_weight_kg: float | None,
+    age_years: float | None,
+    n_grid: int,
+    kp_method: str,
+) -> tuple[dict[str, np.ndarray], float]:
+    """Per posterior-sample steady-state exposures at the regimen's reference dose.
+
+    Builds one renal-CL grid at this interval (one engine re-solve), then reads each
+    quantity at the posterior's renal-scale samples: ``trough`` = the curve at the end
+    of the final dosing interval; ``cmax`` / per-interval ``auc`` from the forward;
+    ``auc24`` = per-interval AUC * (24/tau). Returns the quantity dict and the
+    reference dose ``D_ref`` (= the regimen's per-dose amount).
+    """
+    from sisyphus.mipd.renal_grid import RenalCLForward, build_renal_cl_grid
+
+    grid = build_renal_cl_grid(
+        smiles, regimen, n_grid=n_grid, renal_factor=renal_factor,
+        body_weight_kg=body_weight_kg, age_years=age_years, kp_method=kp_method,
+    )
+    state = RenalCLForward(grid)(r_samples)
+    trough = grid.conc_at(r_samples, float(regimen.last_dose_time_h) + tau)
+    q_ref = {
+        "trough": np.asarray(trough, dtype=float),
+        "cmax": np.asarray(state["cmax"], dtype=float),
+        "auc24": np.asarray(state["auc"], dtype=float) * (24.0 / tau),
+    }
+    d_ref = float(regimen.events[0].dose_mg)
+    return q_ref, d_ref
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `pytest tests/unit/test_mipd_dosing.py -k "lti or interval_reference" -q`
+Expected: PASS (2 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/sisyphus/mipd/dosing.py tests/unit/test_mipd_dosing.py
+git commit -m "feat(mipd): per-interval reference exposures + LTI-exactness guard"
+```
+
+---
+
+### Task 4: `recommend_dose` orchestration
+
+**Files:**
+- Modify: `src/sisyphus/mipd/dosing.py`
+- Test: `tests/unit/test_mipd_dosing.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# append to tests/unit/test_mipd_dosing.py
+
+
+def _engine_trough_at_unit_scale(reg, dose_mg=50.0):
+    """The engine's own r=1 steady-state trough — a stack-independent anchor."""
+    from sisyphus.mipd.renal_grid import build_renal_cl_grid
+
+    g = build_renal_cl_grid(ATENOLOL, reg, n_grid=5)
+    return float(g.conc_at(np.array([1.0]), reg.last_dose_time_h + 8.0)[0])
+
+
+def test_recommend_rejects_oral_regimen():
+    oral = DosingRegimen.oral_repeated(dose_mg=50.0, interval_h=8.0, n_doses=3)
+    with pytest.raises(ValueError, match="IV"):
+        recommend_dose(ATENOLOL, oral, [], DoseTarget((Constraint("trough", low=0.1),)))
+
+
+def test_recommend_hits_feasible_trough_window():
+    # Condition on a trough at the r=1 prediction so the posterior concentrates near r=1,
+    # then ask for a window centered at 1.5x that trough -> recommender scales the dose ~1.5x
+    # and the median trough lands in the window. Window defined from the engine's own
+    # prediction -> stack-independent.
+    reg = _iv_regimen()
+    base = _engine_trough_at_unit_scale(reg)
+    obs = [MeasuredConc(value=base, t=reg.last_dose_time_h + 8.0, cv=0.1)]
+    lo, hi = 1.3 * base, 1.7 * base
+    rec = recommend_dose(
+        ATENOLOL, reg, obs, DoseTarget((Constraint("trough", low=lo, high=hi),)),
+        candidate_intervals=(8.0,), n_grid=5, n_samples=4000, seed=0,
+    )
+    assert lo <= rec.trough.point <= hi
+    assert rec.attainment_prob > 0.5
+    assert isinstance(rec, DoseRecommendation)
+
+
+def test_recommend_tie_break_prefers_longer_interval():
+    # A loose Cmax ceiling both q8 and q24 attain ~1.0 -> the longer interval wins.
+    reg = _iv_regimen()
+    from sisyphus.mipd.renal_grid import build_renal_cl_grid
+
+    g = build_renal_cl_grid(ATENOLOL, reg, n_grid=5)
+    i1 = int(np.argmin(np.abs(np.log(g.r_grid))))  # r≈1 index
+    loose = 10.0 * float(g.cmax[i1])
+    rec = recommend_dose(
+        ATENOLOL, reg, [], DoseTarget((Constraint("cmax", high=loose),)),
+        candidate_intervals=(8.0, 24.0), n_grid=5, n_samples=2000, seed=0,
+    )
+    assert rec.interval_h == 24.0
+    assert rec.attainment_prob == pytest.approx(1.0, abs=1e-6)
+    assert len(rec.candidates) == 2
+
+
+def test_recommend_dose_step_rounds_dose():
+    reg = _iv_regimen()
+    base = _engine_trough_at_unit_scale(reg)
+    obs = [MeasuredConc(value=base, t=reg.last_dose_time_h + 8.0, cv=0.1)]
+    rec = recommend_dose(
+        ATENOLOL, reg, obs, DoseTarget((Constraint("trough", low=1.3 * base, high=1.7 * base),)),
+        candidate_intervals=(8.0,), dose_step_mg=25.0, n_grid=5, n_samples=2000, seed=0,
+    )
+    assert rec.dose_mg % 25.0 == pytest.approx(0.0, abs=1e-9)
+
+
+def test_recommend_extreme_crcl_warns_and_individualizes():
+    reg = _iv_regimen()
+    rec = recommend_dose(
+        ATENOLOL, reg, [], DoseTarget((Constraint("trough", low=0.01),)),
+        covariates=Covariates(crcl_ml_min=3), candidate_intervals=(8.0,),
+        n_grid=5, n_samples=2000, seed=0,
+    )
+    assert any("crcl" in w.lower() for w in rec.warnings)
+
+
+def test_recommend_infeasible_target_warns():
+    # A trough window far above anything any dose+posterior sample can place the MEDIAN
+    # into consistently -> attainment < 0.5 soft warning. Use contradictory two-sided
+    # bounds the spread can't satisfy: a razor-thin window with a very wide prior (no obs).
+    reg = _iv_regimen()
+    base = _engine_trough_at_unit_scale(reg)
+    rec = recommend_dose(
+        ATENOLOL, reg, [],  # no obs -> wide renal prior -> wide trough spread
+        DoseTarget((Constraint("trough", low=0.999 * base, high=1.001 * base),)),
+        candidate_intervals=(8.0,), n_grid=5, n_samples=3000, seed=0,
+    )
+    assert rec.attainment_prob < 0.5
+    assert any("attainment" in w.lower() for w in rec.warnings)
+
+
+def test_recommend_renal_scale_shifts_with_observation():
+    # Observing a trough well BELOW the r=1 prediction => patient clears faster => r>1.
+    reg = _iv_regimen()
+    base = _engine_trough_at_unit_scale(reg)
+    obs = [MeasuredConc(value=0.5 * base, t=reg.last_dose_time_h + 8.0, cv=0.2)]
+    rec = recommend_dose(
+        ATENOLOL, reg, obs, DoseTarget((Constraint("trough", low=0.01),)),
+        candidate_intervals=(8.0,), n_grid=7, n_samples=4000, seed=0,
+    )
+    assert rec.renal_scale.point > 1.0
+
+
+def test_recommend_joint_peak_trough_satisfies_both():
+    # The motivating case for adding the interval knob: a Cmax window AND a trough ceiling
+    # at once. Bounds are derived from the engine's OWN q24 r=1 prediction so a q24 regimen
+    # at ~1x dose is feasible BY CONSTRUCTION (and stack-independent). Assert the
+    # recommendation's median Cmax/trough satisfy BOTH constraints.
+    from sisyphus.mipd.renal_grid import build_renal_cl_grid
+
+    reg = _iv_regimen()
+    reg24 = DosingRegimen.iv_infusion(50.0, 0.5, 24.0, 2)
+    g24 = build_renal_cl_grid(ATENOLOL, reg24, n_grid=5)
+    i24 = int(np.argmin(np.abs(np.log(g24.r_grid))))  # r≈1
+    c24 = float(g24.cmax[i24])
+    t24 = float(g24.conc_at(np.array([1.0]), reg24.last_dose_time_h + 24.0)[0])
+    target = DoseTarget((
+        Constraint("cmax", low=0.5 * c24, high=2.0 * c24),
+        Constraint("trough", high=2.0 * t24),
+    ))
+    # condition near the q8 r=1 trough so the posterior concentrates
+    obs = [MeasuredConc(
+        value=_engine_trough_at_unit_scale(reg), t=reg.last_dose_time_h + 8.0, cv=0.1
+    )]
+    rec = recommend_dose(
+        ATENOLOL, reg, obs, target, candidate_intervals=(8.0, 24.0),
+        n_grid=5, n_samples=4000, seed=0,
+    )
+    assert rec.attainment_prob > 0.5
+    assert 0.5 * c24 <= rec.cmax.point <= 2.0 * c24
+    assert rec.trough.point <= 2.0 * t24
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `pytest tests/unit/test_mipd_dosing.py -k recommend -q`
+Expected: FAIL — `recommend_dose` raises `NotImplementedError`/returns nothing (not yet implemented).
+
+- [ ] **Step 3: Implement `recommend_dose`**
+
+```python
+# append to src/sisyphus/mipd/dosing.py
+
+_INFEASIBLE_ATTAINMENT = 0.5  # soft-warn when the best candidate falls below this
+_TIE_EPS = 1e-3               # attainment ties within this prefer the longer interval
+
+
+def recommend_dose(
+    smiles: str,
+    regimen,
+    observations,
+    target: DoseTarget,
+    *,
+    covariates=None,
+    candidate_intervals: tuple[float, ...] | None = None,
+    dose_step_mg: float | None = None,
+    dose_bounds_mg: tuple[float, float] | None = None,
+    renal_prior_cv: float = 1.0,
+    n_samples: int = 20000,
+    n_grid: int = 13,
+    seed: int = 0,
+    kp_method: str = "rodgers_rowland",
+) -> DoseRecommendation:
+    """Recommend the (dose, interval) that best attains ``target`` under the posterior.
+
+    ``regimen`` is the CURRENT IV regimen the ``observations`` (steady-state troughs)
+    were measured under. The renal-CL posterior is inferred once (a patient property),
+    then propagated to each candidate interval; the dose is solved analytically per
+    interval (LTI). The winner maximizes attainment, breaking ties toward the longer
+    interval. IV-only (oral steady-state TDM is a future layer).
+    """
+    from sisyphus.mipd.tdm import predict_tdm
+    from sisyphus.regimen.types import DEFAULT_IV_NODE, DosingRegimen
+
+    if any(ev.node != DEFAULT_IV_NODE for ev in regimen.events):
+        raise ValueError(
+            "recommend_dose supports IV regimens only (every event must target the IV "
+            f"node {DEFAULT_IV_NODE!r}); oral steady-state TDM is a future extension."
+        )
+
+    observations = list(observations)
+    post = predict_tdm(
+        smiles, regimen, observations, covariates=covariates,
+        renal_prior_cv=renal_prior_cv, n_samples=n_samples, n_grid=n_grid,
+        seed=seed, kp_method=kp_method,
+    )
+    r_samples = post.renal_scale.samples
+    warnings_list = list(post.warnings)
+
+    renal_factor = covariates.renal_factor() if covariates is not None else 1.0
+    body_weight_kg = covariates.body_weight_kg if covariates is not None else None
+    age_years = covariates.age_years if covariates is not None else None
+
+    cur_dose = float(regimen.events[0].dose_mg)
+    cur_dur = float(regimen.events[0].duration_h)
+    cur_last = float(regimen.last_dose_time_h)
+    cur_tau = (
+        float(regimen.events[1].time_h - regimen.events[0].time_h)
+        if regimen.n_doses >= 2 else 24.0
+    )
+
+    base = tuple(candidate_intervals) if candidate_intervals is not None else (8.0, 12.0, 24.0)
+    taus = sorted(set(base + (cur_tau,)))
+
+    rows: list[tuple[CandidateEval, dict[str, np.ndarray], float]] = []
+    for tau in taus:
+        n_doses = max(2, int(round(cur_last / tau)) + 1)
+        reg_tau = DosingRegimen.iv_infusion(
+            dose_mg=cur_dose, duration_h=cur_dur, interval_h=tau, n_doses=n_doses
+        )
+        q_ref, d_ref = _interval_reference(
+            smiles, reg_tau, tau, r_samples, renal_factor=renal_factor,
+            body_weight_kg=body_weight_kg, age_years=age_years, n_grid=n_grid,
+            kp_method=kp_method,
+        )
+        m_lo, m_hi = _sample_m_intervals(q_ref, target)
+        a, b, _ = _max_overlap_region(m_lo, m_hi)
+        dose = _center_m(a, b) * d_ref
+        if dose_step_mg:
+            dose = round(dose / dose_step_mg) * dose_step_mg
+        if dose_bounds_mg is not None:
+            dose = min(max(dose, dose_bounds_mg[0]), dose_bounds_mg[1])
+        m_actual = dose / d_ref if d_ref > 0 else 0.0
+        attain = _attainment(m_actual, m_lo, m_hi)
+        rows.append((
+            CandidateEval(
+                dose_mg=float(dose), interval_h=float(tau), attainment_prob=attain,
+                trough_median=float(np.median(q_ref["trough"] * m_actual)),
+                cmax_median=float(np.median(q_ref["cmax"] * m_actual)),
+                auc24_median=float(np.median(q_ref["auc24"] * m_actual)),
+            ),
+            q_ref, m_actual,
+        ))
+
+    best_attain = max(row[0].attainment_prob for row in rows)
+    winners = [row for row in rows if row[0].attainment_prob >= best_attain - _TIE_EPS]
+    win_cand, win_q, win_m = max(winners, key=lambda row: row[0].interval_h)
+
+    if win_cand.attainment_prob < _INFEASIBLE_ATTAINMENT:
+        warnings_list.append(
+            f"best attainment {win_cand.attainment_prob:.2f} < "
+            f"{_INFEASIBLE_ATTAINMENT:.2f}; target may be infeasible for this patient"
+        )
+
+    return DoseRecommendation(
+        dose_mg=win_cand.dose_mg,
+        interval_h=win_cand.interval_h,
+        attainment_prob=win_cand.attainment_prob,
+        cmax=Posterior(win_q["cmax"] * win_m),
+        trough=Posterior(win_q["trough"] * win_m),
+        auc24=Posterior(win_q["auc24"] * win_m),
+        target=target,
+        candidates=tuple(row[0] for row in rows),
+        renal_scale=post.renal_scale,
+        n_eff=post.n_eff,
+        warnings=tuple(warnings_list),
+    )
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `pytest tests/unit/test_mipd_dosing.py -k recommend -q`
+Expected: PASS (8 tests). If `test_recommend_infeasible_target_warns` is flaky on the spread, widen the razor window's contradiction by using a window entirely above the prior's trough support (e.g. `low=3*base, high=3.01*base`) — keep the assertion that attainment < 0.5 and the warning fires.
+
+- [ ] **Step 5: Run the whole file + ruff**
+
+Run: `pytest tests/unit/test_mipd_dosing.py -q && ruff check src/sisyphus/mipd/dosing.py tests/unit/test_mipd_dosing.py`
+Expected: all green; ruff clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/sisyphus/mipd/dosing.py tests/unit/test_mipd_dosing.py
+git commit -m "feat(mipd): recommend_dose orchestration (per-interval LTI dose solve)"
+```
+
+---
+
+### Task 5: Public exports
+
+**Files:**
+- Modify: `src/sisyphus/mipd/__init__.py`
+- Test: `tests/unit/test_mipd_dosing.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# append to tests/unit/test_mipd_dosing.py
+def test_public_names_importable_from_package():
+    import sisyphus.mipd as m
+
+    for name in ("Constraint", "DoseTarget", "CandidateEval", "DoseRecommendation",
+                 "recommend_dose"):
+        assert hasattr(m, name)
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `pytest tests/unit/test_mipd_dosing.py::test_public_names_importable_from_package -q`
+Expected: FAIL (names not exported from the package).
+
+- [ ] **Step 3: Add the exports**
+
+In `src/sisyphus/mipd/__init__.py`, add an import block after the existing `from sisyphus.mipd.grid import build_cl_grid` line:
+
+```python
+from sisyphus.mipd.dosing import (
+    CandidateEval,
+    Constraint,
+    DoseRecommendation,
+    DoseTarget,
+    recommend_dose,
+)
+```
+
+And add these names to `__all__` (keep the list sorted-ish, matching the existing style):
+
+```python
+    "CandidateEval",
+    "Constraint",
+    "DoseRecommendation",
+    "DoseTarget",
+    "recommend_dose",
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `pytest tests/unit/test_mipd_dosing.py::test_public_names_importable_from_package -q`
+Expected: PASS.
+
+- [ ] **Step 5: Full module test + ruff**
+
+Run: `pytest tests/unit/test_mipd_dosing.py -q && ruff check src/sisyphus/mipd/`
+Expected: all green; ruff clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/sisyphus/mipd/__init__.py tests/unit/test_mipd_dosing.py
+git commit -m "feat(mipd): export dose-recommendation public API"
+```
+
+---
+
+## Final Verification (after all tasks)
+
+- [ ] **Run the full MIPD test suite + the headline-invariance guard:**
+
+```bash
+pytest tests/unit/test_mipd_dosing.py tests/unit/test_mipd_tdm.py \
+       tests/unit/test_mipd_api.py tests/unit/test_mipd_grid.py \
+       tests/unit/test_mipd_renal_grid.py -q
+```
+Expected: all pass. (`recommend_dose` adds no production-path change, so the cached-holdout pin `test_cached_holdout_aafe_is_2p731` is unaffected — but if a broader run is cheap, confirm it still passes.)
+
+- [ ] **Confirm invariants:** `git diff --stat main` shows changes ONLY under `src/sisyphus/mipd/dosing.py`, `src/sisyphus/mipd/__init__.py`, `tests/unit/test_mipd_dosing.py`, and the two `docs/superpowers/` files. No `engine/`, no `predict/`, no `pipeline/`, no holdout/data changes.
+
+- [ ] **Update graphify graph:** `graphify update .` (AST-only, no API cost).
+
+---
+
+## Notes for the implementer
+
+- **Stack-independence is mandatory in directional tests.** Never assert against an absolute concentration magic number; anchor every window to the engine's *own* r=1 prediction (the `_engine_trough_at_unit_scale` helper). The macOS/CI numerics stacks differ ~12% per-drug; a hard-coded concentration will pass locally and fail CI (this exact failure mode bit the IV-TDM directional test, fixed in `df4492c`).
+- **Keep `n_grid` / `n_samples` small in tests** (5–7 / 2000–4000) so each engine re-solve stays fast; production defaults are 13 / 20000.
+- **Do NOT import `_regimen_interval_h`** from `renal_grid` into `dosing.py` — the orchestrator already knows τ (it constructs each candidate regimen). The current interval is read inline from the event times.
+- **`predict_tdm` with empty `observations`** returns the prior as the posterior (renal scale ~ wide lognormal around 1.0) — this is the a-priori recommendation path and is intended.

--- a/docs/superpowers/specs/2026-06-12-mipd-dose-recommendation-design.md
+++ b/docs/superpowers/specs/2026-06-12-mipd-dose-recommendation-design.md
@@ -1,0 +1,232 @@
+# MIPD Dose Recommendation (Target Attainment) — Design
+
+**Date:** 2026-06-12
+**Status:** Approved (design); pending implementation plan
+**Module:** `src/sisyphus/mipd/dosing.py` (new)
+**Builds on:** `mipd/tdm.py` (IV steady-state TDM), `mipd/renal_grid.py` (renal-CL grid forward model), `regimen/solver.py`
+
+---
+
+## 1. Purpose
+
+The MIPD arc inverts the engine-as-prior into a posterior PK given sparse measured data:
+F latent → clint latent → CrCl individualization → steady-state IV TDM (renal-CL latent) →
+weight/age covariates. `predict_tdm` produces a posterior over the patient's renal clearance
+from an observed steady-state trough — but stops at *describing* the patient. It does not close
+the clinical loop: **"so what dose do I give next?"**
+
+This layer adds **dose recommendation / target attainment**: given the conditioned posterior and
+a clinical target (constraints on trough, peak Cmax, and/or AUC24), recommend the
+**(dose, interval)** that maximizes the probability of meeting the target under the posterior.
+
+This is the un-walled lever. SMILES-only headline accuracy is empirically walled
+(`smiles-only-cmax-empirically-walled`); the measured-data / individualization regime is the one
+direction that still moves the clinical value, and dose recommendation is its natural endpoint.
+
+## 2. Key structural fact: the engine is linear in dose (LTI)
+
+The PBPK clearance models are concentration-independent (well-stirred
+`E = fup·CLint/(Q + fup·CLint)`; no saturable Michaelis–Menten in this path). Therefore, at a
+**fixed disposition** (fixed `r`, fixed interval τ), every steady-state exposure quantity scales
+**linearly with dose**:
+
+```
+trough(D, τ) = (D / D_ref) · trough(D_ref, τ)
+cmax(D, τ)   = (D / D_ref) · cmax(D_ref, τ)
+auc24(D, τ)  = (D / D_ref) · auc24(D_ref, τ)
+```
+
+This is exact for the current engine. Consequence: the **dose** knob is inverted analytically
+from one solve per interval — no per-dose re-solve. The **interval** knob is nonlinear
+(accumulation factor `1/(1 − e^{−kτ})`), so it costs one engine re-solve per candidate interval.
+
+A guard: were saturable kinetics ever added to the engine, LTI would break. The load-bearing
+test (§7.1) asserts LTI holds in the actual engine, so a future nonlinearity would fail loudly.
+
+## 3. Approach (chosen: A — interval re-solve + analytic dose)
+
+The patient's renal-CL posterior `r` is a **patient property**, invariant to the dosing regimen.
+It is inferred **once** from the observed trough under the *current* regimen, then propagated
+forward to each candidate regimen.
+
+- **A (chosen):** infer `r` once (reuse `predict_tdm`); per candidate interval τ_k, build one
+  `build_renal_cl_grid` at τ_k; solve the optimal dose analytically within τ_k via LTI; compare
+  intervals. Cost: 1 inference grid + K interval grids. Exact, reuses the forward model verbatim.
+- **B (rejected):** full 2D (dose × interval) brute grid — re-solves per dose despite LTI, zero
+  accuracy gain, K_τ × K_D cost.
+- **C (rejected):** closed-form 1-compartment accumulation — fastest but discards the platform's
+  graph-derived multi-compartment ODE and would diverge from `predict_tdm`'s own posterior.
+
+## 4. Contracts
+
+New file `src/sisyphus/mipd/dosing.py`. New public names exported from `mipd/__init__.py`.
+**No changes to `PosteriorPK`, `engine/`, or `predict()`** — the recommendation is self-contained.
+
+```python
+@dataclass(frozen=True)
+class Constraint:
+    """A bound on one steady-state PK quantity, evaluated under the posterior."""
+    quantity: str                 # "trough" | "cmax" | "auc24"
+    low: float | None = None      # mg/L (trough/cmax); mg·h/L (auc24)
+    high: float | None = None
+    # __post_init__: quantity in the allowed set; at least one of low/high set;
+    # low <= high when both are set. Else ValueError.
+
+@dataclass(frozen=True)
+class DoseTarget:
+    """A set of constraints. Attainment = P(ALL constraints satisfied) under the posterior."""
+    constraints: tuple[Constraint, ...]
+    # __post_init__: non-empty. Else ValueError.
+
+@dataclass(frozen=True)
+class CandidateEval:
+    """One (dose, interval) row of the recommendation search — for transparency."""
+    dose_mg: float
+    interval_h: float
+    attainment_prob: float
+    trough_median: float
+    cmax_median: float
+    auc24_median: float
+
+@dataclass(frozen=True)
+class DoseRecommendation:
+    dose_mg: float                # recommended per-dose amount
+    interval_h: float             # recommended interval
+    attainment_prob: float        # P(all constraints satisfied) at the recommendation
+    cmax: Posterior               # exposure posteriors AT the recommended regimen
+    trough: Posterior
+    auc24: Posterior
+    target: DoseTarget
+    candidates: tuple[CandidateEval, ...]
+    renal_scale: Posterior        # inferred patient renal-CL posterior (carried through)
+    n_eff: float                  # ESS of the inferred posterior (degeneracy diagnostic)
+    warnings: tuple[str, ...]
+```
+
+**Quantity definitions** (steady state, final dosing interval `[last, last+τ]`):
+- `trough` = concentration at `t = last + τ` (just before the next dose) = `grid.conc_at(r, last+τ)`.
+- `cmax` = max over the final interval (the grid's `cmax`).
+- `auc24` = (∫ over the final interval, the grid's `auc`) × `24/τ`.
+
+## 5. Public function
+
+```python
+def recommend_dose(
+    smiles: str,
+    regimen: DosingRegimen,        # the CURRENT regimen the observation was measured under
+    observations,                  # MeasuredConc trough(s) under the current regimen (may be empty)
+    target: DoseTarget,
+    *,
+    covariates: Covariates | None = None,
+    candidate_intervals: tuple[float, ...] | None = None,  # default (8.0, 12.0, 24.0) ∪ {current τ}
+    dose_step_mg: float | None = None,     # round analytic dose to this increment; None = continuous
+    dose_bounds_mg: tuple[float, float] | None = None,  # clamp recommended dose; None = (0, ∞)
+    renal_prior_cv: float = 1.0,
+    n_samples: int = 20000,
+    n_grid: int = 13,
+    seed: int = 0,
+    kp_method: str = "rodgers_rowland",
+) -> DoseRecommendation
+```
+
+IV-only (matches `predict_tdm`; oral steady-state TDM is a separate future layer).
+
+## 6. Algorithm (data flow)
+
+1. **Validate.** IV-only regimen (every event targets `DEFAULT_IV_NODE`, else `ValueError` mirroring
+   `predict_tdm`'s message). `target` non-empty; each `Constraint` valid (enforced in `__post_init__`).
+2. **Infer the renal posterior once.** Call `predict_tdm(smiles, regimen, observations,
+   covariates=covariates, renal_prior_cv=..., n_samples=..., n_grid=..., seed=..., kp_method=...)`.
+   Take `r_samples = post.renal_scale.samples`, `n_eff = post.n_eff`, and `post.warnings` (covariate
+   warnings). Empty `observations` ⇒ posterior == prior == the a-priori engine (allowed; documented).
+3. **Candidate intervals.** `candidate_intervals or (8.0, 12.0, 24.0)`, unioned with the current
+   regimen's interval (`renal_grid._regimen_interval_h`), sorted and de-duplicated.
+4. **Per interval τ_k (one engine re-solve each):**
+   a. Construct a reference regimen at τ_k: same infusion duration as the current regimen, reference
+      dose `D_ref` = the current per-dose amount, `n_doses_k = max(2, round(current_last_dose_time_h
+      / τ_k) + 1)` (keeps the candidate's time-to-final-dose ≥ the original, so steady state is
+      reached at least as well).
+   b. `grid_k = build_renal_cl_grid(smiles, regimen_τk, n_grid=n_grid, renal_factor=renal_factor,
+      body_weight_kg=..., age_years=..., kp_method=kp_method)` (covariate-derived `renal_factor` and
+      weight/age threaded exactly as `predict_tdm` does).
+   c. Per `r`-sample look up the reference exposures: `trough_ref[i] = grid_k.conc_at(r[i], last+τ_k)`;
+      `cmax_ref[i]` and `auc_int_ref[i]` from `RenalCLForward(grid_k)`; `auc24_ref[i] = auc_int_ref[i]
+      · (24/τ_k)`.
+   d. **Analytic dose solve (LTI).** Each quantity ∝ D, so for the dose multiplier `m = D/D_ref`,
+      sample *i* satisfies all constraints iff `m ∈ [m_lo[i], m_hi[i]]`, where
+      `m_lo[i] = max over lower-bounded constraints c of (low_c / q_ref^c[i])` (0 if none) and
+      `m_hi[i] = min over upper-bounded constraints c of (high_c / q_ref^c[i])` (+∞ if none).
+      `attainment(m) = (1/N) · #{ i : m_lo[i] ≤ m ≤ m_hi[i] }`. The max-attainment m-region is found
+      exactly by a **max-interval-overlap sweep** over the 2N sorted breakpoints.
+   e. Pick `m*` in the max-overlap region by the centering rule (§6.1), apply `dose_step_mg`
+      rounding and `dose_bounds_mg` clamp to get `D = m*·D_ref`, then **re-evaluate** attainment at
+      the actual rounded/clamped dose so the reported number matches the recommended dose.
+   f. Record a `CandidateEval(dose=D, interval=τ_k, attainment, trough/cmax/auc24 medians)`.
+5. **Pick the winner across intervals** (§6.2).
+6. Assemble `DoseRecommendation`: exposure posteriors scaled to the chosen D (`q_ref · D/D_ref`),
+   the full candidate table, `renal_scale`, `n_eff`, and warnings.
+
+### 6.1 Centering rule (within an interval's max-overlap m-region `[a, b]`)
+
+- **Bounded** (a window constrains both sides): `m* = sqrt(a·b)` — geometric midpoint, maximizing the
+  margin to falling out of attainment as the patient's true `r` varies.
+- **Unbounded above** (only lower bounds, e.g. AUC24 ≥ 400): `m* = a` — the **smallest** dose meeting
+  all floors (minimize exposure).
+- **Unbounded below** (only upper bounds, e.g. Cmax ≤ X): `m* = b` — the **largest** dose under all
+  ceilings (maximize efficacy under the safety ceiling).
+
+### 6.2 Cross-interval objective (the user-chosen rule)
+
+Primary: maximize `attainment_prob`. Tie within `ε = 1e-3` → prefer the **longest** interval (fewest
+administrations/day; the point of extended-interval dosing). Remaining tie → the candidate whose
+centering left the largest margin (geometric center of the widest max-overlap region).
+
+## 7. Testing (TDD; load-bearing first)
+
+1. **LTI exactness (load-bearing).** `build_renal_cl_grid` at `2·D_ref` equals the `D_ref` grid's
+   `cmax`/`auc` scaled ×2 within solver tolerance — validates the engine-is-linear premise the whole
+   layer rests on. A future saturable nonlinearity fails here.
+2. Feasible trough window → recommended median trough ∈ window and attainment high.
+3. Longer-interval tie-break: two intervals both attain ~1.0 → the longer τ is chosen.
+4. Centering: recommended median sits central in the window, not at an edge.
+5. Joint peak+trough (aminoglycoside): Cmax window + trough ceiling → recommender selects a longer
+   interval to drop the trough under its ceiling while holding Cmax in window; both constraints attained.
+6. Cmax-ceiling-only → dose pushed just under the ceiling. AUC24-floor-only → smallest dose meeting it.
+7. Oral regimen → `ValueError` ("IV"); invalid targets (empty, bad quantity, no bound, low>high) → `ValueError`.
+8. Covariate warning surfaces in `recommendation.warnings`; `dose_step_mg` respected (recommended dose
+   is a multiple of the step); infeasible target → soft low-attainment warning present; `renal_scale`
+   shifts off 1.0 when an observation is supplied.
+
+**Stack-independence discipline.** Directional tests reference the engine's *own* r=1 predictions
+(no absolute-concentration magic numbers), so assertions hold across the ~12% macOS/CI numerics-stack
+drift — the same fix applied to the IV-TDM directional test (`df4492c`).
+
+## 8. Error handling
+
+`ValueError` (hard) for: oral regimen, empty `target`, invalid `quantity`, a `Constraint` with neither
+bound, `low > high`. `build_renal_cl_grid`'s all-grid-points failure propagates its existing
+`ValueError`. **Soft warning** (returned in `warnings`, not raised) when best attainment `< 0.5`:
+`"best attainment {x:.2f} < 0.50; target may be infeasible for this patient"`.
+
+## 9. Invariants preserved
+
+- `engine/` and `predict()` untouched; reuses `build_renal_cl_grid` / `solve_regimen` verbatim.
+- `PosteriorPK` contract unchanged — `DoseRecommendation` is a new, self-contained type.
+- IV-only (matches `predict_tdm`).
+- Holdout inviolable; the 2.731 Meta headline untouched (new module, off the 4-track path —
+  bit-identical headline guaranteed because no production prediction path changes).
+- No drug-specific branches; the recommender is identity-blind (operates on engine outputs only).
+- All PK quantities are `Posterior`/`Distribution`.
+
+## 10. Defaults (confirmed)
+
+- Candidate intervals default `(8.0, 12.0, 24.0)` ∪ {current τ}.
+- Dose output continuous analytic, with optional `dose_step_mg` rounding and `dose_bounds_mg` clamp.
+- Infeasibility soft-warning threshold = attainment `< 0.5`.
+
+## 11. Out of scope (future layers)
+
+- Oral steady-state TDM (F + clint latent jointly) — `recommend_dose` is IV-only, mirroring `predict_tdm`.
+- Discrete vial-size optimization beyond `dose_step_mg` rounding.
+- Loading-dose / non-steady-state titration schedules.
+- PK/PD (effect-compartment) targets — constraints are on exposure quantities only.

--- a/src/sisyphus/mipd/__init__.py
+++ b/src/sisyphus/mipd/__init__.py
@@ -27,6 +27,13 @@ from sisyphus.mipd.core import (
     PosteriorPK,
     sir_posterior,
 )
+from sisyphus.mipd.dosing import (
+    CandidateEval,
+    Constraint,
+    DoseRecommendation,
+    DoseTarget,
+    recommend_dose,
+)
 from sisyphus.mipd.grid import build_cl_grid
 from sisyphus.mipd.meta import MetaTracks, build_meta_tracks, meta_blend_cmax
 
@@ -49,4 +56,9 @@ __all__ = [
     "CLPrior",
     "sir_posterior_2d",
     "build_cl_grid",
+    "CandidateEval",
+    "Constraint",
+    "DoseRecommendation",
+    "DoseTarget",
+    "recommend_dose",
 ]

--- a/src/sisyphus/mipd/dosing.py
+++ b/src/sisyphus/mipd/dosing.py
@@ -163,5 +163,42 @@ def _center_m(a: float, b: float) -> float:
     return math.sqrt(a * b)
 
 
+def _interval_reference(
+    smiles: str,
+    regimen,
+    tau: float,
+    r_samples: np.ndarray,
+    *,
+    renal_factor: float,
+    body_weight_kg: float | None,
+    age_years: float | None,
+    n_grid: int,
+    kp_method: str,
+) -> tuple[dict[str, np.ndarray], float]:
+    """Per posterior-sample steady-state exposures at the regimen's reference dose.
+
+    Builds one renal-CL grid at this interval (one engine re-solve), then reads each
+    quantity at the posterior's renal-scale samples: ``trough`` = the curve at the end
+    of the final dosing interval; ``cmax`` / per-interval ``auc`` from the forward;
+    ``auc24`` = per-interval AUC * (24/tau). Returns the quantity dict and the
+    reference dose ``D_ref`` (= the regimen's per-dose amount).
+    """
+    from sisyphus.mipd.renal_grid import RenalCLForward, build_renal_cl_grid
+
+    grid = build_renal_cl_grid(
+        smiles, regimen, n_grid=n_grid, renal_factor=renal_factor,
+        body_weight_kg=body_weight_kg, age_years=age_years, kp_method=kp_method,
+    )
+    state = RenalCLForward(grid)(r_samples)
+    trough = grid.conc_at(r_samples, float(regimen.last_dose_time_h) + tau)
+    q_ref = {
+        "trough": np.asarray(trough, dtype=float),
+        "cmax": np.asarray(state["cmax"], dtype=float),
+        "auc24": np.asarray(state["auc"], dtype=float) * (24.0 / tau),
+    }
+    d_ref = float(regimen.events[0].dose_mg)
+    return q_ref, d_ref
+
+
 def recommend_dose(*args, **kwargs):  # implemented in Task 4
     raise NotImplementedError("recommend_dose is implemented in a later task")

--- a/src/sisyphus/mipd/dosing.py
+++ b/src/sisyphus/mipd/dosing.py
@@ -182,6 +182,9 @@ def _interval_reference(
     of the final dosing interval; ``cmax`` / per-interval ``auc`` from the forward;
     ``auc24`` = per-interval AUC * (24/tau). Returns the quantity dict and the
     reference dose ``D_ref`` (= the regimen's per-dose amount).
+
+    Precondition: ``tau`` must equal the regimen's own dosing interval (the orchestrator
+    builds the regimen and tau together), so the trough time stays within the grid horizon.
     """
     from sisyphus.mipd.renal_grid import RenalCLForward, build_renal_cl_grid
 
@@ -200,5 +203,147 @@ def _interval_reference(
     return q_ref, d_ref
 
 
-def recommend_dose(*args, **kwargs):  # implemented in Task 4
-    raise NotImplementedError("recommend_dose is implemented in a later task")
+_INFEASIBLE_ATTAINMENT = 0.5  # soft-warn when the best candidate falls below this
+_TIE_EPS = 1e-3               # attainment ties within this prefer the longer interval
+
+
+def _tie_tolerance(n_samples: int) -> float:
+    """Attainment-tie band: ~2x the binomial SE of a proportion at ``n_samples``.
+
+    Attainment is ``mean(boolean)`` over the posterior particles, so its sampling SE
+    is ``sqrt(p(1-p)/n) <= sqrt(0.25/n)``. Two intervals whose attainment differs by
+    less than this are statistically tied and the longer-interval preference should
+    decide between them; a fixed ``_TIE_EPS`` below the SE would let MC noise defeat
+    that rule. Floored at ``_TIE_EPS``.
+    """
+    return max(_TIE_EPS, 2.0 * math.sqrt(0.25 / max(n_samples, 1)))
+
+
+def recommend_dose(
+    smiles: str,
+    regimen,
+    observations,
+    target: DoseTarget,
+    *,
+    covariates=None,
+    candidate_intervals: tuple[float, ...] | None = None,
+    dose_step_mg: float | None = None,
+    dose_bounds_mg: tuple[float, float] | None = None,
+    renal_prior_cv: float = 1.0,
+    n_samples: int = 20000,
+    n_grid: int = 13,
+    seed: int = 0,
+    kp_method: str = "rodgers_rowland",
+) -> DoseRecommendation:
+    """Recommend the (dose, interval) that best attains ``target`` under the posterior.
+
+    ``regimen`` is the CURRENT IV regimen the ``observations`` (steady-state troughs)
+    were measured under. The renal-CL posterior is inferred once (a patient property),
+    then propagated to each candidate interval; the dose is solved analytically per
+    interval (LTI). The winner maximizes attainment, breaking ties toward the longer
+    interval. IV-only (oral steady-state TDM is a future layer).
+
+    Callers should check ``attainment_prob`` (and ``warnings``) before acting: an
+    infeasible target still returns the best-effort longest-interval candidate.
+    Steady state for a candidate interval is approximated by ``n_doses =
+    max(2, round(cur_last/tau)+1)`` doses; a slowly-accumulating (long-half-life) drug
+    at a long candidate interval may be modeled slightly below true steady state.
+    The current regimen is assumed uniform (dose/duration/interval read from its first
+    events); a non-uniform input regimen is reconstructed as uniform.
+    """
+    from sisyphus.mipd.tdm import predict_tdm
+    from sisyphus.regimen.types import DEFAULT_IV_NODE, DosingRegimen
+
+    if any(ev.node != DEFAULT_IV_NODE for ev in regimen.events):
+        raise ValueError(
+            "recommend_dose supports IV regimens only (every event must target the IV "
+            f"node {DEFAULT_IV_NODE!r}); oral steady-state TDM is a future extension."
+        )
+
+    if float(regimen.events[0].dose_mg) <= 0.0:
+        raise ValueError("recommend_dose requires the current regimen's dose to be > 0")
+
+    observations = list(observations)
+    post = predict_tdm(
+        smiles, regimen, observations, covariates=covariates,
+        renal_prior_cv=renal_prior_cv, n_samples=n_samples, n_grid=n_grid,
+        seed=seed, kp_method=kp_method,
+    )
+    r_samples = post.renal_scale.samples
+    warnings_list = list(post.warnings)
+
+    renal_factor = covariates.renal_factor() if covariates is not None else 1.0
+    body_weight_kg = covariates.body_weight_kg if covariates is not None else None
+    age_years = covariates.age_years if covariates is not None else None
+
+    cur_dose = float(regimen.events[0].dose_mg)
+    cur_dur = float(regimen.events[0].duration_h)
+    cur_last = float(regimen.last_dose_time_h)
+    cur_tau = (
+        float(regimen.events[1].time_h - regimen.events[0].time_h)
+        if regimen.n_doses >= 2 else 24.0
+    )
+
+    base = tuple(candidate_intervals) if candidate_intervals is not None else (8.0, 12.0, 24.0)
+    taus = sorted(set(base + (cur_tau,)))
+
+    rows: list[tuple[CandidateEval, dict[str, np.ndarray], float]] = []
+    for tau in taus:
+        n_doses = max(2, int(round(cur_last / tau)) + 1)
+        reg_tau = DosingRegimen.iv_infusion(
+            dose_mg=cur_dose, duration_h=cur_dur, interval_h=tau, n_doses=n_doses
+        )
+        q_ref, d_ref = _interval_reference(
+            smiles, reg_tau, tau, r_samples, renal_factor=renal_factor,
+            body_weight_kg=body_weight_kg, age_years=age_years, n_grid=n_grid,
+            kp_method=kp_method,
+        )
+        m_lo, m_hi = _sample_m_intervals(q_ref, target)
+        a, b, _ = _max_overlap_region(m_lo, m_hi)
+        dose = _center_m(a, b) * d_ref
+        if dose_step_mg:
+            dose = round(dose / dose_step_mg) * dose_step_mg
+        if dose_bounds_mg is not None:
+            dose = min(max(dose, dose_bounds_mg[0]), dose_bounds_mg[1])
+        m_actual = dose / d_ref
+        attain = _attainment(m_actual, m_lo, m_hi)
+        rows.append((
+            CandidateEval(
+                dose_mg=float(dose), interval_h=float(tau), attainment_prob=attain,
+                trough_median=float(np.median(q_ref["trough"] * m_actual)),
+                cmax_median=float(np.median(q_ref["cmax"] * m_actual)),
+                auc24_median=float(np.median(q_ref["auc24"] * m_actual)),
+            ),
+            q_ref, m_actual,
+        ))
+
+    best_attain = max(row[0].attainment_prob for row in rows)
+    tie_eps = _tie_tolerance(r_samples.size)
+    winners = [row for row in rows if row[0].attainment_prob >= best_attain - tie_eps]
+    win_cand, win_q, win_m = max(winners, key=lambda row: row[0].interval_h)
+
+    if win_cand.dose_mg <= 0.0:
+        warnings_list.append(
+            f"recommended dose rounded to {win_cand.dose_mg:g} mg under the dose "
+            f"granularity (dose_step_mg={dose_step_mg}); the optimal dose is below one step"
+        )
+
+    if win_cand.attainment_prob < _INFEASIBLE_ATTAINMENT:
+        warnings_list.append(
+            f"best attainment {win_cand.attainment_prob:.2f} < "
+            f"{_INFEASIBLE_ATTAINMENT:.2f}; target may be infeasible for this patient"
+        )
+
+    return DoseRecommendation(
+        dose_mg=win_cand.dose_mg,
+        interval_h=win_cand.interval_h,
+        attainment_prob=win_cand.attainment_prob,
+        cmax=Posterior(win_q["cmax"] * win_m),
+        trough=Posterior(win_q["trough"] * win_m),
+        auc24=Posterior(win_q["auc24"] * win_m),
+        target=target,
+        candidates=tuple(row[0] for row in rows),
+        renal_scale=post.renal_scale,
+        n_eff=post.n_eff,
+        warnings=tuple(warnings_list),
+    )

--- a/src/sisyphus/mipd/dosing.py
+++ b/src/sisyphus/mipd/dosing.py
@@ -1,0 +1,94 @@
+"""Dose recommendation (target attainment) over the IV steady-state TDM posterior.
+
+``predict_tdm`` infers the patient's renal-clearance posterior from a measured
+steady-state trough. This module closes the clinical loop: given a target (a set of
+constraints on the steady-state trough, peak Cmax, and/or AUC24), recommend the
+(dose, interval) that maximizes the probability the target is met under that
+posterior.
+
+The engine is **linear in dose** (concentration-independent clearance — no saturable
+Michaelis-Menten in this path), so at a fixed disposition every steady-state exposure
+scales linearly with dose. The dose knob is therefore inverted *analytically* (one
+solve per interval, then a max-interval-overlap sweep over per-sample feasible
+dose-multiplier ranges); only the interval knob (nonlinear accumulation) costs an
+engine re-solve. See docs/superpowers/specs/2026-06-12-mipd-dose-recommendation-design.md.
+"""
+from __future__ import annotations
+
+import math  # noqa: F401  (used by Task 4 solver)
+from dataclasses import dataclass
+
+import numpy as np  # noqa: F401  (used by Task 4 solver)
+
+from sisyphus.mipd.core import Posterior
+
+_QUANTITIES = ("trough", "cmax", "auc24")
+
+
+@dataclass(frozen=True)
+class Constraint:
+    """A bound on one steady-state PK quantity, evaluated under the posterior.
+
+    ``quantity`` is one of ``"trough"`` / ``"cmax"`` / ``"auc24"``. At least one of
+    ``low`` / ``high`` must be set (mg/L for trough/cmax, mg*h/L for auc24).
+    """
+
+    quantity: str
+    low: float | None = None
+    high: float | None = None
+
+    def __post_init__(self) -> None:
+        if self.quantity not in _QUANTITIES:
+            raise ValueError(f"quantity must be one of {_QUANTITIES}, got {self.quantity!r}")
+        if self.low is None and self.high is None:
+            raise ValueError("Constraint needs at least one of low/high")
+        if self.low is not None and self.low < 0:
+            raise ValueError(f"low must be >= 0, got {self.low}")
+        if self.high is not None and self.high <= 0:
+            raise ValueError(f"high must be > 0, got {self.high}")
+        if self.low is not None and self.high is not None and self.low > self.high:
+            raise ValueError(f"low {self.low} > high {self.high}")
+
+
+@dataclass(frozen=True)
+class DoseTarget:
+    """A set of constraints. Attainment = P(ALL constraints satisfied) under the posterior."""
+
+    constraints: tuple[Constraint, ...]
+
+    def __post_init__(self) -> None:
+        if not self.constraints:
+            raise ValueError("DoseTarget needs at least one constraint")
+
+
+@dataclass(frozen=True)
+class CandidateEval:
+    """One (dose, interval) row of the recommendation search — for transparency."""
+
+    dose_mg: float
+    interval_h: float
+    attainment_prob: float
+    trough_median: float
+    cmax_median: float
+    auc24_median: float
+
+
+@dataclass(frozen=True)
+class DoseRecommendation:
+    """The recommended regimen and the exposure posteriors it produces."""
+
+    dose_mg: float
+    interval_h: float
+    attainment_prob: float
+    cmax: Posterior
+    trough: Posterior
+    auc24: Posterior
+    target: DoseTarget
+    candidates: tuple[CandidateEval, ...]
+    renal_scale: Posterior
+    n_eff: float
+    warnings: tuple[str, ...]
+
+
+def recommend_dose(*args, **kwargs):  # implemented in Task 4
+    raise NotImplementedError("recommend_dose is implemented in a later task")

--- a/src/sisyphus/mipd/dosing.py
+++ b/src/sisyphus/mipd/dosing.py
@@ -15,10 +15,10 @@ engine re-solve. See docs/superpowers/specs/2026-06-12-mipd-dose-recommendation-
 """
 from __future__ import annotations
 
-import math  # noqa: F401  (used by Task 4 solver)
+import math
 from dataclasses import dataclass
 
-import numpy as np  # noqa: F401  (used by Task 4 solver)
+import numpy as np
 
 from sisyphus.mipd.core import Posterior
 
@@ -88,6 +88,79 @@ class DoseRecommendation:
     renal_scale: Posterior
     n_eff: float
     warnings: tuple[str, ...]
+
+
+def _sample_m_intervals(
+    q_ref: dict[str, np.ndarray], target: DoseTarget
+) -> tuple[np.ndarray, np.ndarray]:
+    """Per posterior-sample feasible dose-multiplier interval ``[m_lo, m_hi]``.
+
+    Each exposure scales linearly with the dose multiplier ``m`` (LTI). A constraint
+    ``low <= m*q_ref <= high`` becomes ``m in [low/q_ref, high/q_ref]``; intersecting
+    across constraints gives ``[m_lo[i], m_hi[i]]`` per sample (0 / +inf when a side
+    is unbounded).
+
+    A sample whose reference exposure is ~0 (floored to 1e-300) gets m_lo -> inf, which
+    correctly marks it infeasible.
+    """
+    n = len(next(iter(q_ref.values())))
+    m_lo = np.zeros(n)
+    m_hi = np.full(n, np.inf)
+    for c in target.constraints:
+        q = np.maximum(np.asarray(q_ref[c.quantity], dtype=float), 1e-300)
+        if c.low is not None:
+            m_lo = np.maximum(m_lo, c.low / q)
+        if c.high is not None:
+            m_hi = np.minimum(m_hi, c.high / q)
+    return m_lo, m_hi
+
+
+def _attainment(m: float, m_lo: np.ndarray, m_hi: np.ndarray) -> float:
+    """Fraction of posterior samples whose feasible interval covers dose-multiplier ``m``."""
+    return float(np.mean((m_lo <= m) & (m <= m_hi)))
+
+
+def _max_overlap_region(
+    m_lo: np.ndarray, m_hi: np.ndarray
+) -> tuple[float, float, int]:
+    """Dose-multiplier segment ``[a, b]`` where the most sample-intervals overlap.
+
+    Classic max-interval-overlap sweep. At a tie, a start is ordered before an end so
+    a point shared by ``[., x]`` and ``[x, .]`` counts both (closed intervals). Returns
+    ``(a, b, count)``; ``b`` may be ``inf`` (only-floor constraints). Empty sample
+    intervals (``m_lo > m_hi``) are dropped.
+    """
+    feasible = m_lo <= m_hi
+    los = m_lo[feasible]
+    his = m_hi[feasible]
+    if los.size == 0:
+        return (0.0, 0.0, 0)
+    pts = np.concatenate([los, his])
+    kinds = np.concatenate([np.ones(los.size), -np.ones(his.size)])  # +1 start, -1 end
+    order = np.lexsort((-kinds, pts))  # by point asc; starts (+1) before ends (-1) at ties
+    pts = pts[order]
+    cov = np.cumsum(kinds[order])
+    best_i = int(np.argmax(cov))
+    a = float(pts[best_i])
+    b = float(pts[best_i + 1]) if best_i + 1 < pts.size else a
+    return (a, b, int(cov[best_i]))
+
+
+def _center_m(a: float, b: float) -> float:
+    """Pick the dose multiplier within the max-overlap region ``[a, b]``.
+
+    Bounded window -> geometric midpoint (max margin). Only floors (b == inf) ->
+    smallest dose meeting them (``a``). Only ceilings (a == 0) -> largest dose under
+    them (``b``).
+
+    If the region is unbounded above with a==0 (a floor that binds no sample), keep the
+    current dose (1.0).
+    """
+    if not math.isfinite(b):
+        return a if a > 0.0 else 1.0
+    if a <= 0.0:
+        return b
+    return math.sqrt(a * b)
 
 
 def recommend_dose(*args, **kwargs):  # implemented in Task 4

--- a/tests/unit/test_mipd_dosing.py
+++ b/tests/unit/test_mipd_dosing.py
@@ -292,3 +292,11 @@ def test_recommend_dose_rounded_to_zero_warns():
     )
     assert rec.dose_mg == 0.0
     assert any("granularity" in w.lower() for w in rec.warnings)
+
+
+def test_public_names_importable_from_package():
+    import sisyphus.mipd as m
+
+    for name in ("Constraint", "DoseTarget", "CandidateEval", "DoseRecommendation",
+                 "recommend_dose"):
+        assert hasattr(m, name)

--- a/tests/unit/test_mipd_dosing.py
+++ b/tests/unit/test_mipd_dosing.py
@@ -1,0 +1,55 @@
+"""Unit + integration tests for mipd.dosing (dose recommendation / target attainment)."""
+import numpy as np  # noqa: F401  (used by later-task tests)
+import pytest
+
+from sisyphus.mipd.clgrid import MeasuredConc  # noqa: F401  (used by later-task tests)
+from sisyphus.mipd.covariates import Covariates  # noqa: F401  (used by later-task tests)
+from sisyphus.mipd.dosing import (
+    CandidateEval,  # noqa: F401  (used by later-task tests)
+    Constraint,
+    DoseRecommendation,  # noqa: F401  (used by later-task tests)
+    DoseTarget,
+    recommend_dose,  # noqa: F401  (used by later-task tests)
+)
+from sisyphus.regimen.types import DosingRegimen
+
+ATENOLOL = "CC(C)NCC(O)COc1ccc(CC(N)=O)cc1"  # high-fup, renally cleared
+
+
+def _iv_regimen():
+    return DosingRegimen.iv_infusion(dose_mg=50.0, duration_h=0.5, interval_h=8.0, n_doses=5)
+
+
+def test_constraint_rejects_unknown_quantity():
+    with pytest.raises(ValueError, match="quantity"):
+        Constraint(quantity="halflife", low=1.0)
+
+
+def test_constraint_rejects_no_bound():
+    with pytest.raises(ValueError, match="at least one"):
+        Constraint(quantity="trough")
+
+
+def test_constraint_rejects_low_above_high():
+    with pytest.raises(ValueError, match="low"):
+        Constraint(quantity="trough", low=5.0, high=2.0)
+
+
+def test_constraint_rejects_negative_low():
+    with pytest.raises(ValueError, match="low must be >= 0"):
+        Constraint(quantity="trough", low=-1.0)
+
+
+def test_constraint_rejects_nonpositive_high():
+    with pytest.raises(ValueError, match="high must be > 0"):
+        Constraint(quantity="cmax", high=0.0)
+
+
+def test_constraint_accepts_one_sided():
+    c = Constraint(quantity="cmax", high=10.0)
+    assert c.low is None and c.high == 10.0
+
+
+def test_dose_target_rejects_empty():
+    with pytest.raises(ValueError, match="at least one constraint"):
+        DoseTarget(constraints=())

--- a/tests/unit/test_mipd_dosing.py
+++ b/tests/unit/test_mipd_dosing.py
@@ -7,6 +7,7 @@ import pytest
 from sisyphus.mipd.clgrid import MeasuredConc  # noqa: F401  (used by later-task tests)
 from sisyphus.mipd.covariates import Covariates  # noqa: F401  (used by later-task tests)
 from sisyphus.mipd.dosing import (
+    _TIE_EPS,
     CandidateEval,  # noqa: F401  (used by later-task tests)
     Constraint,
     DoseRecommendation,  # noqa: F401  (used by later-task tests)
@@ -16,6 +17,7 @@ from sisyphus.mipd.dosing import (
     _interval_reference,
     _max_overlap_region,
     _sample_m_intervals,
+    _tie_tolerance,
     recommend_dose,  # noqa: F401  (used by later-task tests)
 )
 from sisyphus.regimen.types import DosingRegimen
@@ -153,3 +155,140 @@ def test_interval_reference_returns_quantities_at_reference_dose():
     g = build_renal_cl_grid(ATENOLOL, reg, n_grid=5)
     expect = float(g.conc_at(np.array([1.0]), reg.last_dose_time_h + 8.0)[0])
     assert q_ref["trough"][0] == pytest.approx(expect, rel=1e-9)
+
+
+def _engine_trough_at_unit_scale(reg, dose_mg=50.0):
+    """The engine's own r=1 steady-state trough — a stack-independent anchor."""
+    from sisyphus.mipd.renal_grid import build_renal_cl_grid
+
+    g = build_renal_cl_grid(ATENOLOL, reg, n_grid=5)
+    return float(g.conc_at(np.array([1.0]), reg.last_dose_time_h + 8.0)[0])
+
+
+def test_recommend_rejects_oral_regimen():
+    oral = DosingRegimen.oral_repeated(dose_mg=50.0, interval_h=8.0, n_doses=3)
+    with pytest.raises(ValueError, match="IV"):
+        recommend_dose(ATENOLOL, oral, [], DoseTarget((Constraint("trough", low=0.1),)))
+
+
+def test_recommend_hits_feasible_trough_window():
+    reg = _iv_regimen()
+    base = _engine_trough_at_unit_scale(reg)
+    obs = [MeasuredConc(value=base, t=reg.last_dose_time_h + 8.0, cv=0.1)]
+    lo, hi = 1.3 * base, 1.7 * base
+    rec = recommend_dose(
+        ATENOLOL, reg, obs, DoseTarget((Constraint("trough", low=lo, high=hi),)),
+        candidate_intervals=(8.0,), n_grid=5, n_samples=4000, seed=0,
+    )
+    assert lo <= rec.trough.point <= hi
+    assert rec.attainment_prob > 0.5
+    assert isinstance(rec, DoseRecommendation)
+
+
+def test_recommend_tie_break_prefers_longer_interval():
+    reg = _iv_regimen()
+    from sisyphus.mipd.renal_grid import build_renal_cl_grid
+
+    g = build_renal_cl_grid(ATENOLOL, reg, n_grid=5)
+    i1 = int(np.argmin(np.abs(np.log(g.r_grid))))  # r≈1 index
+    loose = 10.0 * float(g.cmax[i1])
+    rec = recommend_dose(
+        ATENOLOL, reg, [], DoseTarget((Constraint("cmax", high=loose),)),
+        candidate_intervals=(8.0, 24.0), n_grid=5, n_samples=2000, seed=0,
+    )
+    assert rec.interval_h == 24.0
+    assert rec.attainment_prob == pytest.approx(1.0, abs=1e-6)
+    assert len(rec.candidates) == 2
+
+
+def test_recommend_dose_step_rounds_dose():
+    reg = _iv_regimen()
+    base = _engine_trough_at_unit_scale(reg)
+    obs = [MeasuredConc(value=base, t=reg.last_dose_time_h + 8.0, cv=0.1)]
+    rec = recommend_dose(
+        ATENOLOL, reg, obs, DoseTarget((Constraint("trough", low=1.3 * base, high=1.7 * base),)),
+        candidate_intervals=(8.0,), dose_step_mg=25.0, n_grid=5, n_samples=2000, seed=0,
+    )
+    assert rec.dose_mg % 25.0 == pytest.approx(0.0, abs=1e-9)
+
+
+def test_recommend_extreme_crcl_warns_and_individualizes():
+    reg = _iv_regimen()
+    rec = recommend_dose(
+        ATENOLOL, reg, [], DoseTarget((Constraint("trough", low=0.01),)),
+        covariates=Covariates(crcl_ml_min=3), candidate_intervals=(8.0,),
+        n_grid=5, n_samples=2000, seed=0,
+    )
+    assert any("crcl" in w.lower() for w in rec.warnings)
+
+
+def test_recommend_infeasible_target_warns():
+    reg = _iv_regimen()
+    base = _engine_trough_at_unit_scale(reg)
+    rec = recommend_dose(
+        ATENOLOL, reg, [],  # no obs -> wide renal prior -> wide trough spread
+        DoseTarget((Constraint("trough", low=0.999 * base, high=1.001 * base),)),
+        candidate_intervals=(8.0,), n_grid=5, n_samples=3000, seed=0,
+    )
+    assert rec.attainment_prob < 0.5
+    assert any("attainment" in w.lower() for w in rec.warnings)
+
+
+def test_recommend_renal_scale_shifts_with_observation():
+    reg = _iv_regimen()
+    base = _engine_trough_at_unit_scale(reg)
+    obs = [MeasuredConc(value=0.5 * base, t=reg.last_dose_time_h + 8.0, cv=0.2)]
+    rec = recommend_dose(
+        ATENOLOL, reg, obs, DoseTarget((Constraint("trough", low=0.01),)),
+        candidate_intervals=(8.0,), n_grid=7, n_samples=4000, seed=0,
+    )
+    assert rec.renal_scale.point > 1.0
+
+
+def test_recommend_joint_peak_trough_satisfies_both():
+    from sisyphus.mipd.renal_grid import build_renal_cl_grid
+
+    reg = _iv_regimen()
+    reg24 = DosingRegimen.iv_infusion(50.0, 0.5, 24.0, 2)
+    g24 = build_renal_cl_grid(ATENOLOL, reg24, n_grid=5)
+    i24 = int(np.argmin(np.abs(np.log(g24.r_grid))))  # r≈1
+    c24 = float(g24.cmax[i24])
+    t24 = float(g24.conc_at(np.array([1.0]), reg24.last_dose_time_h + 24.0)[0])
+    target = DoseTarget((
+        Constraint("cmax", low=0.5 * c24, high=2.0 * c24),
+        Constraint("trough", high=2.0 * t24),
+    ))
+    obs = [MeasuredConc(
+        value=_engine_trough_at_unit_scale(reg), t=reg.last_dose_time_h + 8.0, cv=0.1
+    )]
+    rec = recommend_dose(
+        ATENOLOL, reg, obs, target, candidate_intervals=(8.0, 24.0),
+        n_grid=5, n_samples=4000, seed=0,
+    )
+    assert rec.attainment_prob > 0.5
+    assert 0.5 * c24 <= rec.cmax.point <= 2.0 * c24
+    assert rec.trough.point <= 2.0 * t24
+
+
+def test_tie_tolerance_scales_with_samples():
+    assert _tie_tolerance(20000) == pytest.approx(2.0 * math.sqrt(0.25 / 20000))
+    assert _tie_tolerance(2000) > _tie_tolerance(20000)  # fewer samples -> wider band
+    assert _tie_tolerance(10**12) == pytest.approx(_TIE_EPS)  # floor engages at huge n
+
+
+def test_recommend_rejects_zero_dose_regimen():
+    reg = DosingRegimen.iv_infusion(dose_mg=0.0, duration_h=0.5, interval_h=8.0, n_doses=3)
+    with pytest.raises(ValueError, match="dose to be > 0"):
+        recommend_dose(ATENOLOL, reg, [], DoseTarget((Constraint("trough", low=0.1),)))
+
+
+def test_recommend_dose_rounded_to_zero_warns():
+    # A tiny trough ceiling forces a small optimal dose; a huge dose_step rounds it to 0 mg.
+    reg = _iv_regimen()
+    base = _engine_trough_at_unit_scale(reg)
+    rec = recommend_dose(
+        ATENOLOL, reg, [], DoseTarget((Constraint("trough", high=0.001 * base),)),
+        candidate_intervals=(8.0,), dose_step_mg=1000.0, n_grid=5, n_samples=2000, seed=0,
+    )
+    assert rec.dose_mg == 0.0
+    assert any("granularity" in w.lower() for w in rec.warnings)

--- a/tests/unit/test_mipd_dosing.py
+++ b/tests/unit/test_mipd_dosing.py
@@ -1,5 +1,7 @@
 """Unit + integration tests for mipd.dosing (dose recommendation / target attainment)."""
-import numpy as np  # noqa: F401  (used by later-task tests)
+import math
+
+import numpy as np
 import pytest
 
 from sisyphus.mipd.clgrid import MeasuredConc  # noqa: F401  (used by later-task tests)
@@ -9,6 +11,10 @@ from sisyphus.mipd.dosing import (
     Constraint,
     DoseRecommendation,  # noqa: F401  (used by later-task tests)
     DoseTarget,
+    _attainment,
+    _center_m,
+    _max_overlap_region,
+    _sample_m_intervals,
     recommend_dose,  # noqa: F401  (used by later-task tests)
 )
 from sisyphus.regimen.types import DosingRegimen
@@ -53,3 +59,60 @@ def test_constraint_accepts_one_sided():
 def test_dose_target_rejects_empty():
     with pytest.raises(ValueError, match="at least one constraint"):
         DoseTarget(constraints=())
+
+
+def test_sample_m_intervals_two_sided_window():
+    # q_ref = 1.0 for all; trough window [2, 4] -> m must be in [2, 4].
+    q_ref = {"trough": np.array([1.0, 1.0, 1.0])}
+    target = DoseTarget((Constraint("trough", low=2.0, high=4.0),))
+    m_lo, m_hi = _sample_m_intervals(q_ref, target)
+    assert np.allclose(m_lo, 2.0)
+    assert np.allclose(m_hi, 4.0)
+
+
+def test_sample_m_intervals_unbounded_sides():
+    q_ref = {"cmax": np.array([2.0, 2.0])}
+    # ceiling only -> m_lo == 0, m_hi == high/q
+    lo, hi = _sample_m_intervals(q_ref, DoseTarget((Constraint("cmax", high=10.0),)))
+    assert np.allclose(lo, 0.0) and np.allclose(hi, 5.0)
+    # floor only -> m_lo == low/q, m_hi == inf
+    lo, hi = _sample_m_intervals(q_ref, DoseTarget((Constraint("cmax", low=4.0),)))
+    assert np.allclose(lo, 2.0) and np.all(np.isinf(hi))
+
+
+def test_max_overlap_region_picks_densest_segment():
+    # intervals: [0,2], [1,3], [1,4]  -> max overlap (3) on [1, 2]
+    m_lo = np.array([0.0, 1.0, 1.0])
+    m_hi = np.array([2.0, 3.0, 4.0])
+    a, b, count = _max_overlap_region(m_lo, m_hi)
+    assert count == 3
+    assert a == pytest.approx(1.0) and b == pytest.approx(2.0)
+
+
+def test_max_overlap_region_all_infeasible_returns_zero():
+    # every sample interval empty (m_lo > m_hi) -> no attainable dose multiplier
+    a, b, count = _max_overlap_region(np.array([5.0, 6.0]), np.array([1.0, 2.0]))
+    assert (a, b, count) == (0.0, 0.0, 0)
+
+
+def test_max_overlap_region_single_feasible_interval():
+    a, b, count = _max_overlap_region(np.array([2.0]), np.array([4.0]))
+    assert count == 1 and a == pytest.approx(2.0) and b == pytest.approx(4.0)
+
+
+def test_attainment_counts_covering_intervals():
+    m_lo = np.array([0.0, 1.0, 1.0])
+    m_hi = np.array([2.0, 3.0, 4.0])
+    assert _attainment(1.5, m_lo, m_hi) == pytest.approx(1.0)   # all three cover 1.5
+    assert _attainment(3.5, m_lo, m_hi) == pytest.approx(1.0 / 3.0)  # only [1,4]
+
+
+def test_center_m_rules():
+    assert _center_m(2.0, 8.0) == pytest.approx(4.0)        # bounded -> geometric mid sqrt(16)
+    assert _center_m(3.0, math.inf) == pytest.approx(3.0)   # only floors -> smallest (a)
+    assert _center_m(0.0, 5.0) == pytest.approx(5.0)        # only ceilings -> largest (b)
+
+
+def test_center_m_floor_only_nonbinding_keeps_current_dose():
+    # b == inf and a == 0 (floor non-binding for all samples) -> keep current dose (1.0)
+    assert _center_m(0.0, math.inf) == pytest.approx(1.0)

--- a/tests/unit/test_mipd_dosing.py
+++ b/tests/unit/test_mipd_dosing.py
@@ -13,6 +13,7 @@ from sisyphus.mipd.dosing import (
     DoseTarget,
     _attainment,
     _center_m,
+    _interval_reference,
     _max_overlap_region,
     _sample_m_intervals,
     recommend_dose,  # noqa: F401  (used by later-task tests)
@@ -116,3 +117,39 @@ def test_center_m_rules():
 def test_center_m_floor_only_nonbinding_keeps_current_dose():
     # b == inf and a == 0 (floor non-binding for all samples) -> keep current dose (1.0)
     assert _center_m(0.0, math.inf) == pytest.approx(1.0)
+
+
+def test_lti_exactness_grid_scales_linearly_with_dose():
+    # The whole layer rests on the engine being linear in dose. Doubling the dose must
+    # exactly double steady-state Cmax and AUC at every renal scale. A future saturable
+    # nonlinearity would fail HERE.
+    from sisyphus.mipd.renal_grid import build_renal_cl_grid
+
+    g1 = build_renal_cl_grid(
+        ATENOLOL, DosingRegimen.iv_infusion(50.0, 0.5, 8.0, 5), n_grid=5
+    )
+    g2 = build_renal_cl_grid(
+        ATENOLOL, DosingRegimen.iv_infusion(100.0, 0.5, 8.0, 5), n_grid=5
+    )
+    assert np.allclose(g2.cmax, 2.0 * g1.cmax, rtol=1e-6)
+    assert np.allclose(g2.auc, 2.0 * g1.auc, rtol=1e-6)
+
+
+def test_interval_reference_returns_quantities_at_reference_dose():
+    reg = _iv_regimen()
+    r = np.array([1.0, 1.0, 1.0])
+    q_ref, d_ref = _interval_reference(
+        ATENOLOL, reg, 8.0, r, renal_factor=1.0, body_weight_kg=None,
+        age_years=None, n_grid=5, kp_method="rodgers_rowland",
+    )
+    assert d_ref == 50.0
+    assert set(q_ref) == {"trough", "cmax", "auc24"}
+    for key in q_ref:
+        assert q_ref[key].shape == (3,)
+        assert np.all(q_ref[key] > 0)
+    # trough must equal the grid's own conc at the end of the final interval at r=1.
+    from sisyphus.mipd.renal_grid import build_renal_cl_grid
+
+    g = build_renal_cl_grid(ATENOLOL, reg, n_grid=5)
+    expect = float(g.conc_at(np.array([1.0]), reg.last_dose_time_h + 8.0)[0])
+    assert q_ref["trough"][0] == pytest.approx(expect, rel=1e-9)


### PR DESCRIPTION
## Summary

Adds **`recommend_dose`** — the MIPD layer that closes the TDM loop from *describing* a patient to *acting*: given an IV regimen, a measured steady-state trough, and a clinical target (constraints on **trough / peak Cmax / AUC24**), it recommends the **(dose, interval)** that maximizes the probability the target is met under the conditioned posterior.

New self-contained module `src/sisyphus/mipd/dosing.py` (+ exports). **No `engine/`, `predict()`, `PosteriorPK`, holdout, or data changes** — the 2.731 Meta headline is untouched (the feature is off the 4-track path).

### Approach
- The patient's renal-CL posterior `r` is inferred **once** via `predict_tdm` (a patient property, regimen-invariant).
- The engine is **linear in dose** (LTI — verified to ~5.6e-9 by a guard test), so the dose knob is solved **analytically** (a max-interval-overlap sweep over per-posterior-sample feasible dose-multiplier ranges) — no per-dose re-solve.
- Only the **interval** knob (nonlinear accumulation) costs one engine re-solve per candidate τ.
- Winner = max attainment → ties (within an **n-aware** binomial-SE band) → **longer interval**. Constraints compose, so AUC-guided vancomycin *and* joint peak+trough aminoglycoside dosing both fall out of one abstraction.

### Public API (`from sisyphus.mipd import ...`)
`Constraint`, `DoseTarget`, `CandidateEval`, `DoseRecommendation`, `recommend_dose`.

## Test plan
- [x] 29 unit/integration tests in `tests/unit/test_mipd_dosing.py`; full MIPD suite (91) green; full unit suite **938 passed, 12 skipped**.
- [x] **Load-bearing LTI-exactness guard** (`2·D_ref` grid == `D_ref` grid ×2) — a future saturable nonlinearity fails loudly.
- [x] Behavioral: feasible-window hit, longer-interval tie-break, joint peak+trough, dose-step rounding, extreme-CrCl warning, infeasible-target warning, renal-scale shift, oral-rejection, zero-dose rejection, granularity (rounded-to-0) warning.
- [x] Directional tests are **stack-independent** (anchored to the engine's own r≈1 predictions, not magic numbers) — survives the ~12% macOS/CI numerics drift.
- [x] Built via spec → plan → subagent-driven development (per-task spec + code-quality review; final holistic review = READY TO MERGE).

Spec: `docs/superpowers/specs/2026-06-12-mipd-dose-recommendation-design.md` · Plan: `docs/superpowers/plans/2026-06-12-mipd-dose-recommendation.md`

## Follow-up (non-blocking, from final review)
- **Name overlap** with the older `sisyphus.regimen.dosing.recommend_dose`/`target_css` (a simple linear `target_css` adjuster the CLI uses). Different capability (this is the Bayesian posterior + dose+interval search + multi-constraint layer); no Python shadowing since `mipd` re-exports only its own. Worth deciding whether `mipd.dosing` supersedes `regimen.dosing`.
- Spec §6.2's tertiary tie-break ("remaining tie → largest centering margin") is unreachable (intervals are distinct) and not implemented — trim the spec line or implement.
- A few edge paths (fully-infeasible, AUC24-floor-only) are unit-covered but not end-to-end.

IV-only (oral steady-state TDM is a future layer).