### PR TITLE
feat(mipd): Cockcroft-Gault CrCl estimation

### DIFF
--- a/docs/superpowers/plans/2026-06-12-mipd-cockcroft-gault.md
+++ b/docs/superpowers/plans/2026-06-12-mipd-cockcroft-gault.md
@@ -1,0 +1,287 @@
+# Cockcroft-Gault CrCl Estimation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a Cockcroft-Gault creatinine-clearance estimator and a renal-only `Covariates` factory, so a caller with routine labs (age/weight/sex/serum-creatinine) can individualize the engine's renal clearance without a measured CrCl.
+
+**Architecture:** Two additions to the existing `src/sisyphus/mipd/covariates.py`: a pure module-level function `cockcroft_gault(...)` (formula + validation + advisory warnings) and an additive classmethod `Covariates.from_cockcroft_gault(...)` that returns `Covariates(crcl_ml_min=estimate)` (renal-only — weight/age are estimate inputs, not stored, so no `generate_physiology` rebuild). `renal_factor()` is unchanged.
+
+**Tech Stack:** Python 3.10+, stdlib `math`/`logging`, frozen dataclass, pytest.
+
+**Spec:** `docs/superpowers/specs/2026-06-12-mipd-cockcroft-gault-crcl-design.md`
+
+**Conventions:** `from __future__ import annotations`; `logging` (not print); type hints; `ruff` line length 100; constants `UPPER_SNAKE` with a source comment; commits `type(mipd): description` with NO `Co-Authored-By`/AI trailer.
+
+**Current `covariates.py` shape (for orientation):**
+- Imports: `from __future__ import annotations` then `from dataclasses import dataclass`.
+- `_REFERENCE_GFR_ML_MIN = 125.0`.
+- `@dataclass(frozen=True) class Covariates` with fields `crcl_ml_min/body_weight_kg/age_years` (all `float | None = None`), `__post_init__` (positivity validation), `renal_factor()` (returns `crcl_ml_min/125.0` or `1.0`), `has_physiology()`, `warnings()`.
+- No `math`/`logging` imports yet.
+
+**Test file:** `tests/unit/test_mipd_covariates.py` already exists — APPEND to it.
+
+---
+
+## File Structure
+
+- **Modify** `src/sisyphus/mipd/covariates.py` — add CG constants + `cockcroft_gault()` (Task 1) and the `from_cockcroft_gault()` classmethod (Task 2). One file, one responsibility (covariate derivation). ~73 → ~120 lines.
+- **Modify** `tests/unit/test_mipd_covariates.py` — append CG function tests (Task 1) + factory tests (Task 2).
+
+No `mipd/__init__.py` change (per spec §8 — `cockcroft_gault`/`Covariates` stay in the submodule).
+
+---
+
+### Task 1: `cockcroft_gault` pure function
+
+**Files:**
+- Modify: `src/sisyphus/mipd/covariates.py`
+- Test: `tests/unit/test_mipd_covariates.py`
+
+- [ ] **Step 1: Write the failing tests** — APPEND to `tests/unit/test_mipd_covariates.py`. Ensure these imports exist at the top of the file (add only the missing ones): `import logging`, `import pytest`, and `from sisyphus.mipd.covariates import Covariates, cockcroft_gault`. (Do NOT add `import math` to the test file — the tests use `float("nan")`/`float("inf")`, so a `math` import would be an unused-import ruff F401 failure.)
+
+```python
+def test_cockcroft_gault_male_cancelling_anchor():
+    # weight 72, scr 1.0 cancels the 72 denominator -> CrCl == 140 - age
+    assert cockcroft_gault(60, 72.0, 1.0, "male") == pytest.approx(80.0)
+
+
+def test_cockcroft_gault_female_factor():
+    assert cockcroft_gault(60, 72.0, 1.0, "female") == pytest.approx(68.0)  # 80 * 0.85
+
+
+def test_cockcroft_gault_non_cancelling_anchor():
+    # full arithmetic: (140-40)*80 / (72*1.2) = 8000 / 86.4 = 92.5926
+    assert cockcroft_gault(40, 80.0, 1.2, "male") == pytest.approx(92.5926, rel=1e-4)
+
+
+def test_cockcroft_gault_sex_case_insensitive():
+    assert cockcroft_gault(60, 72.0, 1.0, "Male") == pytest.approx(80.0)
+    assert cockcroft_gault(60, 72.0, 1.0, "FEMALE") == pytest.approx(68.0)
+
+
+@pytest.mark.parametrize(
+    "kwargs, match",
+    [
+        ({"age_years": 60, "weight_kg": 72, "scr_mg_dl": 1.0, "sex": "x"}, "sex"),
+        ({"age_years": 0, "weight_kg": 72, "scr_mg_dl": 1.0, "sex": "male"}, "age_years"),
+        ({"age_years": 140, "weight_kg": 72, "scr_mg_dl": 1.0, "sex": "male"}, "age_years"),
+        ({"age_years": 60, "weight_kg": 0, "scr_mg_dl": 1.0, "sex": "male"}, "weight_kg"),
+        ({"age_years": 60, "weight_kg": 72, "scr_mg_dl": 0, "sex": "male"}, "scr_mg_dl"),
+        ({"age_years": float("nan"), "weight_kg": 72, "scr_mg_dl": 1.0, "sex": "male"}, "finite"),
+        ({"age_years": 60, "weight_kg": float("inf"), "scr_mg_dl": 1.0, "sex": "male"}, "finite"),
+    ],
+)
+def test_cockcroft_gault_rejects_bad_inputs(kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        cockcroft_gault(**kwargs)
+
+
+def test_cockcroft_gault_pediatric_warns(caplog):
+    with caplog.at_level(logging.WARNING):
+        cockcroft_gault(10, 30.0, 1.0, "male")
+    assert "not validated" in caplog.text.lower()
+
+
+def test_cockcroft_gault_low_scr_warns(caplog):
+    with caplog.at_level(logging.WARNING):
+        cockcroft_gault(60, 72.0, 0.4, "male")
+    assert "overestimate" in caplog.text.lower()
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `python -m pytest tests/unit/test_mipd_covariates.py -k cockcroft -q`
+Expected: FAIL — `ImportError: cannot import name 'cockcroft_gault'`.
+
+- [ ] **Step 3: Implement the function + constants** in `src/sisyphus/mipd/covariates.py`.
+
+(a) Change the imports block at the top from:
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass
+```
+to:
+```python
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+```
+
+(b) Immediately AFTER the existing `_REFERENCE_GFR_ML_MIN = 125.0` line, add the CG constants and the function:
+```python
+# Cockcroft & Gault, Nephron 1976: CrCl = (140-age)*wt*(0.85 if female)/(72*SCr_mg/dL).
+_CG_AGE_CONSTANT = 140.0
+_CG_SCR_DENOMINATOR_DL = 72.0
+_CG_FEMALE_FACTOR = 0.85
+_CG_MAX_AGE_YEARS = 140.0          # validation floor: 140 - age must stay > 0
+_CG_PEDIATRIC_AGE_YEARS = 18.0     # CG is not validated below this age
+_CG_LOW_SCR_MG_DL = 0.6            # low SCr -> CrCl overestimation risk (low muscle mass)
+
+
+def cockcroft_gault(
+    age_years: float, weight_kg: float, scr_mg_dl: float, sex: str
+) -> float:
+    """Estimate creatinine clearance (mL/min) by the Cockcroft-Gault equation.
+
+    ``CrCl = (140 - age) * weight_kg * (0.85 if female else 1.0) / (72 * SCr_mg/dL)``.
+    ``scr_mg_dl`` is serum creatinine in mg/dL (NOT SI µmol/L; divide µmol/L by 88.42).
+    ``sex`` is "male"/"female" (case-insensitive). Returns an ABSOLUTE CrCl in mL/min
+    (body size enters via the weight term) — the quantity ``Covariates.crcl_ml_min``
+    expects; do not pass a BSA-normalized eGFR there instead. With actual body weight,
+    CG overestimates CrCl in obese patients (adjusted body weight needs height — future).
+
+    Raises ``ValueError`` on non-finite, non-positive, or out-of-range inputs. Logs a
+    (non-blocking) warning for age < 18 (CG unvalidated) and for very low SCr
+    (overestimation in reduced muscle mass).
+    """
+    for _name, _value in (
+        ("age_years", age_years), ("weight_kg", weight_kg), ("scr_mg_dl", scr_mg_dl)
+    ):
+        if not math.isfinite(_value):
+            raise ValueError(f"{_name} must be finite, got {_value}")
+    sex_l = sex.strip().lower()
+    if sex_l not in ("male", "female"):
+        raise ValueError(f"sex must be 'male' or 'female', got {sex!r}")
+    if age_years <= 0 or age_years >= _CG_MAX_AGE_YEARS:
+        raise ValueError(
+            f"age_years must be in (0, {_CG_MAX_AGE_YEARS}), got {age_years}"
+        )
+    if weight_kg <= 0:
+        raise ValueError(f"weight_kg must be > 0, got {weight_kg}")
+    if scr_mg_dl <= 0:
+        raise ValueError(f"scr_mg_dl must be > 0, got {scr_mg_dl}")
+
+    if age_years < _CG_PEDIATRIC_AGE_YEARS:
+        logger.warning(
+            "Cockcroft-Gault is not validated for age < %s (got %s); consider Schwartz.",
+            _CG_PEDIATRIC_AGE_YEARS, age_years,
+        )
+    if scr_mg_dl < _CG_LOW_SCR_MG_DL:
+        logger.warning(
+            "serum creatinine %s mg/dL is low; in patients with reduced muscle mass "
+            "(elderly/cachectic) Cockcroft-Gault may overestimate CrCl.", scr_mg_dl,
+        )
+
+    crcl = (
+        (_CG_AGE_CONSTANT - age_years) * weight_kg
+        / (_CG_SCR_DENOMINATOR_DL * scr_mg_dl)
+    )
+    if sex_l == "female":
+        crcl *= _CG_FEMALE_FACTOR
+    return crcl
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `python -m pytest tests/unit/test_mipd_covariates.py -k cockcroft -q`
+Expected: PASS (all `cockcroft_*` tests, ~7 cases incl. the 7 parametrized rejections).
+
+- [ ] **Step 5: ruff**
+
+Run: `ruff check src/sisyphus/mipd/covariates.py tests/unit/test_mipd_covariates.py`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/sisyphus/mipd/covariates.py tests/unit/test_mipd_covariates.py
+git commit -m "feat(mipd): Cockcroft-Gault CrCl estimator (cockcroft_gault)"
+```
+
+---
+
+### Task 2: `Covariates.from_cockcroft_gault` factory (renal-only)
+
+**Files:**
+- Modify: `src/sisyphus/mipd/covariates.py`
+- Test: `tests/unit/test_mipd_covariates.py`
+
+- [ ] **Step 1: Write the failing tests** — APPEND to `tests/unit/test_mipd_covariates.py` (imports from Task 1 already cover `Covariates`/`pytest`):
+
+```python
+def test_from_cockcroft_gault_is_renal_only():
+    cov = Covariates.from_cockcroft_gault(60, 72.0, 1.0, "male")
+    assert cov.crcl_ml_min == pytest.approx(80.0)
+    assert cov.body_weight_kg is None   # renal-only: weight/age are estimate inputs, not stored
+    assert cov.age_years is None
+    assert cov.has_physiology() is False  # so no generate_physiology rebuild is triggered
+
+
+def test_from_cockcroft_gault_feeds_renal_factor():
+    cov = Covariates.from_cockcroft_gault(60, 72.0, 1.0, "male")
+    assert cov.renal_factor() == pytest.approx(80.0 / 125.0)
+
+
+def test_from_cockcroft_gault_propagates_validation():
+    with pytest.raises(ValueError, match="sex"):
+        Covariates.from_cockcroft_gault(60, 72.0, 1.0, "unknown")
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `python -m pytest tests/unit/test_mipd_covariates.py -k from_cockcroft -q`
+Expected: FAIL — `AttributeError: type object 'Covariates' has no attribute 'from_cockcroft_gault'`.
+
+- [ ] **Step 3: Implement the classmethod.** Add it to the `Covariates` class body, placed AFTER the `warnings()` method (the last method), at class-body indentation:
+
+```python
+    @classmethod
+    def from_cockcroft_gault(
+        cls, age_years: float, weight_kg: float, scr_mg_dl: float, sex: str
+    ) -> "Covariates":
+        """Build Covariates with crcl_ml_min ESTIMATED via Cockcroft-Gault (renal-only).
+
+        Use when CrCl is not directly measured. Weight/age are inputs to the estimate
+        ONLY — they are not stored, so ``has_physiology()`` stays False and no
+        ``generate_physiology`` graph rebuild is triggered: this individualizes renal
+        CL only. For whole-body size individualization, pass body_weight_kg/age_years to
+        ``Covariates(...)`` directly. The estimate then flows through ``renal_factor()``
+        exactly like a measured CrCl.
+        """
+        return cls(crcl_ml_min=cockcroft_gault(age_years, weight_kg, scr_mg_dl, sex))
+```
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `python -m pytest tests/unit/test_mipd_covariates.py -k from_cockcroft -q`
+Expected: PASS (3 tests). Then the whole file: `python -m pytest tests/unit/test_mipd_covariates.py -q` — expect all green.
+
+- [ ] **Step 5: ruff**
+
+Run: `ruff check src/sisyphus/mipd/covariates.py tests/unit/test_mipd_covariates.py`
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/sisyphus/mipd/covariates.py tests/unit/test_mipd_covariates.py
+git commit -m "feat(mipd): Covariates.from_cockcroft_gault renal-only factory"
+```
+
+---
+
+## Final Verification (after both tasks)
+
+- [ ] **Run the covariates + dependent MIPD suites:**
+
+```bash
+python -m pytest tests/unit/test_mipd_covariates.py tests/unit/test_mipd_api.py \
+       tests/unit/test_mipd_tdm.py -q
+```
+Expected: all pass. (The factory is additive and renal_factor() is unchanged, so the api/tdm covariate paths are unaffected — confirm.)
+
+- [ ] **Confirm scope:** `git diff main --stat` shows ONLY `src/sisyphus/mipd/covariates.py`, `tests/unit/test_mipd_covariates.py`, and the spec/plan docs. No `engine/`, `predict/`, `pipeline/`, `__init__.py`, or data changes.
+
+- [ ] **Update graphify graph:** `graphify update .` (AST-only, no API cost).
+
+## Notes for the implementer
+
+- The `from __future__ import annotations` already present makes the `-> "Covariates"` self-reference fine; keep the quotes for clarity.
+- `caplog.text` (not `record.message`) is used in the warning tests because the warnings use `%s` lazy formatting — `caplog.text` contains the formatted output.
+- Do NOT round SCr up to 1.0 and do NOT cap the output — the spec deliberately prefers the honest estimate + warning (KDIGO does not endorse round-up).
+- Two commits total (one per task). No `Co-Authored-By`/AI trailer.

--- a/docs/superpowers/specs/2026-06-12-mipd-cockcroft-gault-crcl-design.md
+++ b/docs/superpowers/specs/2026-06-12-mipd-cockcroft-gault-crcl-design.md
@@ -1,0 +1,132 @@
+# Cockcroft-Gault CrCl Estimation — Design
+
+**Date:** 2026-06-12
+**Status:** Approved (design); pending implementation plan
+**Module:** `src/sisyphus/mipd/covariates.py` (extend)
+**Composes with:** `Covariates.renal_factor()` (the renal individualization lever)
+
+---
+
+## 1. Purpose
+
+The MIPD covariate path individualizes the engine's renal clearance from a **measured**
+creatinine clearance (`Covariates.crcl_ml_min` → `renal_factor() = CrCl/125`). In practice
+CrCl is often not measured directly; it is **estimated** from age, weight, sex, and serum
+creatinine. This adds the **Cockcroft-Gault** estimator and a factory that feeds its output
+into the existing renal path, so a caller with routine labs (not a 24 h urine collection) can
+still individualize renal clearance.
+
+## 2. The equation (Cockcroft & Gault, *Nephron* 1976)
+
+```
+CrCl (mL/min) = (140 - age_years) * weight_kg * (0.85 if female else 1.0) / (72 * SCr_mg/dL)
+```
+
+The output is an **absolute** CrCl in mL/min (body size enters via the weight term). This is
+the right quantity for this engine: the reference renal model is glomerular-filtration-only
+with an **absolute** reference GFR of 125 mL/min (7.5 L/h, reference 70 kg / 1.73 m² man; see
+`predict/ivive.py`), so `renal_factor = CG_CrCl / 125` is dimensionally coherent and a larger
+patient correctly scales renal CL up.
+
+**Pitfall (documented):** do NOT feed a BSA-normalized eGFR (CKD-EPI/MDRD, mL/min/1.73 m²)
+into `crcl_ml_min` — only absolute CrCl composes with this path. CG gives absolute, so it is
+the correct estimator to wire in here.
+
+## 3. Surface (additions to `covariates.py`)
+
+```python
+def cockcroft_gault(age_years: float, weight_kg: float, scr_mg_dl: float, sex: str) -> float:
+    """Estimate creatinine clearance (mL/min) by the Cockcroft-Gault equation."""
+
+# classmethod on Covariates:
+@classmethod
+def from_cockcroft_gault(cls, age_years, weight_kg, scr_mg_dl, sex) -> "Covariates":
+    """Covariates with crcl_ml_min ESTIMATED via Cockcroft-Gault (renal-only)."""
+    return cls(crcl_ml_min=cockcroft_gault(age_years, weight_kg, scr_mg_dl, sex))
+```
+
+`renal_factor()` is **unchanged** — the estimate flows through it identically to a measured CrCl.
+
+### Constants (cited)
+`_CG_AGE_CONSTANT = 140.0`, `_CG_SCR_DENOMINATOR_DL = 72.0`, `_CG_FEMALE_FACTOR = 0.85` (Cockcroft
+& Gault 1976); `_CG_MAX_AGE_YEARS = 140.0` (validation floor so `140-age > 0`);
+`_CG_PEDIATRIC_AGE_YEARS = 18.0`, `_CG_LOW_SCR_MG_DL = 0.6` (advisory thresholds).
+
+## 4. Inputs & conventions
+
+- **sex**: `"male"` / `"female"`, case-insensitive (`.strip().lower()`); anything else → `ValueError`.
+- **scr_mg_dl**: serum creatinine in **mg/dL** (the formula's native unit; the `_mg_dl` suffix in
+  the parameter name is the unit guardrail). SI µmol/L is NOT auto-converted (÷88.42 to convert).
+- **weight**: **actual** body weight (classic CG). Caveat (documented): with actual weight, CG
+  **overestimates** CrCl in obese patients; ideal/adjusted body weight needs height and is a
+  future extension.
+
+## 5. Renal-only output (the deliberate trade-off)
+
+`from_cockcroft_gault` returns `Covariates(crcl_ml_min=estimate)` — it does **not** store
+`body_weight_kg`/`age_years`, so `has_physiology()` stays False and **no `generate_physiology`
+graph rebuild** is triggered. Weight/age are inputs to the *estimate* only.
+
+**Documented consequence:** this individualizes **renal CL only**. A large/small patient gets
+renal CL scaled by CG (which used their weight), but Vd / hepatic CL remain at the 70 kg
+reference body — an internal inconsistency that is the accepted renal-only scope. For
+whole-body size individualization, a caller passes `body_weight_kg`/`age_years` explicitly to
+`Covariates` (which triggers `generate_physiology`), separately from this factory.
+
+## 6. Validation & edge handling
+
+`cockcroft_gault` raises `ValueError` on:
+- any input not finite (`not math.isfinite(x)`) — prevents silent `nan`/`inf` propagation
+  (a `nan` would pass every `<= 0` check and poison `renal_factor()`).
+- `sex` not in `{"male", "female"}` (after `strip().lower()`).
+- `age_years <= 0` or `age_years >= _CG_MAX_AGE_YEARS` (keeps `140 - age > 0`).
+- `weight_kg <= 0`.
+- `scr_mg_dl <= 0`.
+
+`cockcroft_gault` emits (non-blocking) `logging.warning`:
+- when `age_years < _CG_PEDIATRIC_AGE_YEARS` (18): "Cockcroft-Gault is not validated for age
+  < 18; consider Schwartz."
+- when `scr_mg_dl < _CG_LOW_SCR_MG_DL` (0.6): "serum creatinine {x} mg/dL is low; in patients
+  with reduced muscle mass (elderly/cachectic) Cockcroft-Gault may overestimate CrCl."
+
+No SCr round-up (Jelliffe) and no output capping: KDIGO does not endorse round-up and it can
+cause underdosing — the honest estimate plus a warning is preferred. Extreme *results* are
+still caught downstream by the existing `Covariates.warnings()` (`crcl` outside [5, 200]).
+
+**Known limitation (documented):** because the output is renal-only (weight/age not stored),
+the CG advisories above are emitted via `logging` at construction and do NOT appear in the
+prediction's structured `warnings` (`PosteriorPK.warnings` / `recommend_dose`). `logging` is
+the sanctioned advisory channel; structured propagation is a possible follow-up.
+
+## 7. Testing (TDD)
+
+- **Formula, cancelling anchor:** `cockcroft_gault(60, 72, 1.0, "male") == 80.0`; `"female"` → `68.0`.
+- **Formula, non-cancelling anchor** (verifies the full arithmetic, not the 72/1.0 coincidence):
+  `cockcroft_gault(40, 80, 1.2, "male") == pytest.approx(92.5926, rel=1e-4)`.
+- **Case-insensitive sex:** `"Male"`, `"FEMALE"` accepted.
+- **Validation `ValueError`:** bad sex; `age <= 0`; `age >= 140`; `weight <= 0`; `scr <= 0`;
+  `nan`/`inf` input.
+- **Factory renal-only:** `from_cockcroft_gault(60, 72, 1.0, "male")` →
+  `crcl_ml_min == pytest.approx(80.0)`, `body_weight_kg is None`, `age_years is None`;
+  `renal_factor() == pytest.approx(80.0 / 125.0)`.
+- **Advisories (`caplog`):** `age_years = 10` logs the pediatric warning; `scr_mg_dl = 0.4`
+  logs the low-SCr warning.
+
+## 8. Scope / invariants
+
+- New helper + additive classmethod only. **No `engine/`, `predict()`, `renal_factor()`, or
+  `Covariates` field changes.** `Covariates` stays frozen; the classmethod is additive.
+- **No `mipd/__init__` export** — `cockcroft_gault` and `Covariates` live in
+  `sisyphus.mipd.covariates` (Covariates is not package-exported today; this does not expand
+  that). Callers: `from sisyphus.mipd.covariates import cockcroft_gault, Covariates`.
+- Bit-identical to current behavior when the factory is not used (no production-path change;
+  holdout / 2.731 headline untouched).
+- `covariates.py` grows ~73 → ~120 lines (gains `import math`, `import logging`).
+
+## 9. Out of scope (future)
+
+- Ideal/adjusted body weight for obesity (needs height).
+- SI (µmol/L) serum-creatinine auto-conversion.
+- Pediatric Schwartz estimator.
+- Structured propagation of CG advisories into the prediction `warnings`.
+- BSA-normalized eGFR (CKD-EPI/MDRD) ingestion with de-normalization.

--- a/src/sisyphus/mipd/covariates.py
+++ b/src/sisyphus/mipd/covariates.py
@@ -137,3 +137,18 @@ class Covariates:
                 "poorly outside (0, 100] yr"
             )
         return tuple(w)
+
+    @classmethod
+    def from_cockcroft_gault(
+        cls, age_years: float, weight_kg: float, scr_mg_dl: float, sex: str
+    ) -> Covariates:
+        """Build Covariates with crcl_ml_min ESTIMATED via Cockcroft-Gault (renal-only).
+
+        Use when CrCl is not directly measured. Weight/age are inputs to the estimate
+        ONLY — they are not stored, so ``has_physiology()`` stays False and no
+        ``generate_physiology`` graph rebuild is triggered: this individualizes renal
+        CL only. For whole-body size individualization, pass body_weight_kg/age_years to
+        ``Covariates(...)`` directly. The estimate then flows through ``renal_factor()``
+        exactly like a measured CrCl.
+        """
+        return cls(crcl_ml_min=cockcroft_gault(age_years, weight_kg, scr_mg_dl, sex))

--- a/src/sisyphus/mipd/covariates.py
+++ b/src/sisyphus/mipd/covariates.py
@@ -9,11 +9,78 @@ docs/superpowers/specs/2026-06-11-mipd-crcl-renal-individualization-design.md.
 """
 from __future__ import annotations
 
+import logging
+import math
 from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
 
 # Reference glomerular filtration rate the engine's renal_clearance assumes
 # (_GFR_L_PER_H = 7.5 L/h ~= 125 mL/min; src/sisyphus/predict/ivive.py:42-43).
 _REFERENCE_GFR_ML_MIN = 125.0
+
+# Cockcroft & Gault, Nephron 1976: CrCl = (140-age)*wt*(0.85 if female)/(72*SCr_mg/dL).
+_CG_AGE_CONSTANT = 140.0
+_CG_SCR_DENOMINATOR_DL = 72.0
+_CG_FEMALE_FACTOR = 0.85
+_CG_MAX_AGE_YEARS = 140.0          # validation floor: 140 - age must stay > 0
+_CG_PEDIATRIC_AGE_YEARS = 18.0     # CG is not validated below this age
+_CG_LOW_SCR_MG_DL = 0.6            # low SCr -> CrCl overestimation risk (low muscle mass)
+
+
+def cockcroft_gault(
+    age_years: float, weight_kg: float, scr_mg_dl: float, sex: str
+) -> float:
+    """Estimate creatinine clearance (mL/min) by the Cockcroft-Gault equation.
+
+    ``CrCl = (140 - age) * weight_kg * (0.85 if female else 1.0) / (72 * SCr_mg/dL)``.
+    ``scr_mg_dl`` is serum creatinine in mg/dL (NOT SI µmol/L; divide µmol/L by 88.42).
+    ``sex`` is "male"/"female" (case-insensitive). Returns an ABSOLUTE CrCl in mL/min
+    (body size enters via the weight term) — the quantity ``Covariates.crcl_ml_min``
+    expects; do not pass a BSA-normalized eGFR there instead. With actual body weight,
+    CG overestimates CrCl in obese patients (adjusted body weight needs height — future).
+
+    Raises ``ValueError`` on non-finite, non-positive, or out-of-range inputs. Logs a
+    (non-blocking) warning for age < 18 (CG unvalidated) and for very low SCr
+    (overestimation in reduced muscle mass).
+    """
+    for _name, _value in (
+        ("age_years", age_years), ("weight_kg", weight_kg), ("scr_mg_dl", scr_mg_dl)
+    ):
+        if not math.isfinite(_value):
+            raise ValueError(f"{_name} must be finite, got {_value}")
+    if not isinstance(sex, str):
+        raise ValueError(f"sex must be 'male' or 'female', got {sex!r}")
+    sex_l = sex.strip().lower()
+    if sex_l not in ("male", "female"):
+        raise ValueError(f"sex must be 'male' or 'female', got {sex!r}")
+    if age_years <= 0 or age_years >= _CG_MAX_AGE_YEARS:
+        raise ValueError(
+            f"age_years must be in (0, {_CG_MAX_AGE_YEARS}), got {age_years}"
+        )
+    if weight_kg <= 0:
+        raise ValueError(f"weight_kg must be > 0, got {weight_kg}")
+    if scr_mg_dl <= 0:
+        raise ValueError(f"scr_mg_dl must be > 0, got {scr_mg_dl}")
+
+    if age_years < _CG_PEDIATRIC_AGE_YEARS:
+        logger.warning(
+            "Cockcroft-Gault is not validated for age < %s (got %s); consider Schwartz.",
+            _CG_PEDIATRIC_AGE_YEARS, age_years,
+        )
+    if scr_mg_dl < _CG_LOW_SCR_MG_DL:
+        logger.warning(
+            "serum creatinine %s mg/dL is low; in patients with reduced muscle mass "
+            "(elderly/cachectic) Cockcroft-Gault may overestimate CrCl.", scr_mg_dl,
+        )
+
+    crcl = (
+        (_CG_AGE_CONSTANT - age_years) * weight_kg
+        / (_CG_SCR_DENOMINATOR_DL * scr_mg_dl)
+    )
+    if sex_l == "female":
+        crcl *= _CG_FEMALE_FACTOR
+    return crcl
 
 
 @dataclass(frozen=True)

--- a/tests/unit/test_mipd_covariates.py
+++ b/tests/unit/test_mipd_covariates.py
@@ -1,5 +1,10 @@
 """Tests for mipd.covariates (Covariates) and mipd.core.ci_floor."""
+import logging
+
+import pytest
+
 from sisyphus.mipd.core import ci_floor
+from sisyphus.mipd.covariates import Covariates, cockcroft_gault
 
 
 def test_ci_floor_off_by_default_fraction():
@@ -24,25 +29,19 @@ def test_ci_floor_nonpositive_mean_passthrough():
 
 
 def test_covariates_renal_factor_unity_at_reference():
-    from sisyphus.mipd.covariates import Covariates
     assert Covariates(crcl_ml_min=125.0).renal_factor() == 1.0
 
 
 def test_covariates_renal_factor_scales_linearly():
-    from sisyphus.mipd.covariates import Covariates
     assert Covariates(crcl_ml_min=62.5).renal_factor() == 0.5
 
 
 def test_covariates_empty_is_no_op():
-    from sisyphus.mipd.covariates import Covariates
     assert Covariates().renal_factor() == 1.0
     assert Covariates(crcl_ml_min=None).renal_factor() == 1.0
 
 
 def test_covariates_rejects_nonpositive_crcl():
-    import pytest
-
-    from sisyphus.mipd.covariates import Covariates
     with pytest.raises(ValueError):
         Covariates(crcl_ml_min=0.0)
     with pytest.raises(ValueError):
@@ -50,9 +49,6 @@ def test_covariates_rejects_nonpositive_crcl():
 
 
 def test_covariates_weight_age_fields_and_validation():
-    import pytest
-
-    from sisyphus.mipd.covariates import Covariates
     c = Covariates(body_weight_kg=10.0, age_years=2.0)
     assert c.body_weight_kg == 10.0 and c.age_years == 2.0
     with pytest.raises(ValueError):
@@ -62,7 +58,6 @@ def test_covariates_weight_age_fields_and_validation():
 
 
 def test_covariates_has_physiology():
-    from sisyphus.mipd.covariates import Covariates
     assert Covariates().has_physiology() is False
     assert Covariates(crcl_ml_min=50).has_physiology() is False  # CrCl is not physiology
     assert Covariates(body_weight_kg=10).has_physiology() is True
@@ -70,16 +65,75 @@ def test_covariates_has_physiology():
 
 
 def test_covariates_renal_factor_unaffected_by_weight_age():
-    from sisyphus.mipd.covariates import Covariates
     # renal is CrCl-only — weight/age never change renal_factor
     assert Covariates(body_weight_kg=10, age_years=80).renal_factor() == 1.0
     assert Covariates(crcl_ml_min=62.5, body_weight_kg=10, age_years=80).renal_factor() == 0.5
 
 
 def test_covariates_warnings_flags_extremes():
-    from sisyphus.mipd.covariates import Covariates
     assert Covariates().warnings() == ()
     assert Covariates(crcl_ml_min=90, body_weight_kg=70, age_years=30).warnings() == ()
     assert any("crcl" in w.lower() for w in Covariates(crcl_ml_min=3).warnings())
     assert any("weight" in w.lower() for w in Covariates(body_weight_kg=1.0).warnings())
     assert any("age" in w.lower() for w in Covariates(age_years=120).warnings())
+
+
+def test_cockcroft_gault_male_cancelling_anchor():
+    # weight 72, scr 1.0 cancels the 72 denominator -> CrCl == 140 - age
+    assert cockcroft_gault(60, 72.0, 1.0, "male") == pytest.approx(80.0)
+
+
+def test_cockcroft_gault_female_factor():
+    assert cockcroft_gault(60, 72.0, 1.0, "female") == pytest.approx(68.0)  # 80 * 0.85
+
+
+def test_cockcroft_gault_non_cancelling_anchor():
+    # full arithmetic: (140-40)*80 / (72*1.2) = 8000 / 86.4 = 92.5926
+    assert cockcroft_gault(40, 80.0, 1.2, "male") == pytest.approx(92.5926, rel=1e-4)
+
+
+def test_cockcroft_gault_sex_case_insensitive():
+    assert cockcroft_gault(60, 72.0, 1.0, "Male") == pytest.approx(80.0)
+    assert cockcroft_gault(60, 72.0, 1.0, "FEMALE") == pytest.approx(68.0)
+
+
+@pytest.mark.parametrize(
+    "kwargs, match",
+    [
+        ({"age_years": 60, "weight_kg": 72, "scr_mg_dl": 1.0, "sex": "x"}, "sex"),
+        ({"age_years": 0, "weight_kg": 72, "scr_mg_dl": 1.0, "sex": "male"}, "age_years"),
+        ({"age_years": 140, "weight_kg": 72, "scr_mg_dl": 1.0, "sex": "male"}, "age_years"),
+        ({"age_years": 60, "weight_kg": 0, "scr_mg_dl": 1.0, "sex": "male"}, "weight_kg"),
+        ({"age_years": 60, "weight_kg": 72, "scr_mg_dl": 0, "sex": "male"}, "scr_mg_dl"),
+        ({"age_years": float("nan"), "weight_kg": 72, "scr_mg_dl": 1.0, "sex": "male"}, "finite"),
+        ({"age_years": 60, "weight_kg": float("inf"), "scr_mg_dl": 1.0, "sex": "male"}, "finite"),
+    ],
+)
+def test_cockcroft_gault_rejects_bad_inputs(kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        cockcroft_gault(**kwargs)
+
+
+def test_cockcroft_gault_pediatric_warns(caplog):
+    with caplog.at_level(logging.WARNING):
+        cockcroft_gault(10, 30.0, 1.0, "male")
+    assert "not validated" in caplog.text.lower()
+
+
+def test_cockcroft_gault_low_scr_warns(caplog):
+    with caplog.at_level(logging.WARNING):
+        cockcroft_gault(60, 72.0, 0.4, "male")
+    assert "overestimate" in caplog.text.lower()
+
+
+def test_cockcroft_gault_rejects_non_string_sex():
+    with pytest.raises(ValueError, match="sex"):
+        cockcroft_gault(60, 72.0, 1.0, None)
+
+
+def test_cockcroft_gault_threshold_boundaries_do_not_warn(caplog):
+    # age exactly 18 and SCr exactly 0.6 are NOT below the thresholds (< not <=) -> no advisory.
+    with caplog.at_level(logging.WARNING):
+        cockcroft_gault(18, 72.0, 0.6, "male")
+    assert "not validated" not in caplog.text.lower()
+    assert "overestimate" not in caplog.text.lower()

--- a/tests/unit/test_mipd_covariates.py
+++ b/tests/unit/test_mipd_covariates.py
@@ -137,3 +137,21 @@ def test_cockcroft_gault_threshold_boundaries_do_not_warn(caplog):
         cockcroft_gault(18, 72.0, 0.6, "male")
     assert "not validated" not in caplog.text.lower()
     assert "overestimate" not in caplog.text.lower()
+
+
+def test_from_cockcroft_gault_is_renal_only():
+    cov = Covariates.from_cockcroft_gault(60, 72.0, 1.0, "male")
+    assert cov.crcl_ml_min == pytest.approx(80.0)
+    assert cov.body_weight_kg is None   # renal-only: weight/age are estimate inputs, not stored
+    assert cov.age_years is None
+    assert cov.has_physiology() is False  # so no generate_physiology rebuild is triggered
+
+
+def test_from_cockcroft_gault_feeds_renal_factor():
+    cov = Covariates.from_cockcroft_gault(60, 72.0, 1.0, "male")
+    assert cov.renal_factor() == pytest.approx(80.0 / 125.0)
+
+
+def test_from_cockcroft_gault_propagates_validation():
+    with pytest.raises(ValueError, match="sex"):
+        Covariates.from_cockcroft_gault(60, 72.0, 1.0, "unknown")


### PR DESCRIPTION
## Summary

Adds **Cockcroft-Gault** creatinine-clearance estimation so a caller with routine labs (age/weight/sex/serum-creatinine) can individualize the engine's renal clearance without a measured CrCl. Two additions to `src/sisyphus/mipd/covariates.py`:

- **`cockcroft_gault(age_years, weight_kg, scr_mg_dl, sex) -> float`** — `CrCl = (140−age)·wt·(0.85 if female)/(72·SCr_mg/dL)`. Returns absolute mL/min (the quantity `crcl_ml_min` expects).
- **`Covariates.from_cockcroft_gault(...)`** — a **renal-only** factory: returns `Covariates(crcl_ml_min=estimate)`, weight/age NOT stored (`has_physiology()` stays False → no `generate_physiology` rebuild). The estimate flows through the unchanged `renal_factor()` exactly like a measured CrCl.

**No `engine/`, `predict()`, `__init__`, `renal_factor()`, or `Covariates`-field changes** — bit-identical when the factory isn't used (2.731 headline untouched).

### Clinical honesty (from the design go-over)
- **Absolute-CrCl coherence:** CG gives absolute mL/min; the engine reference (125 mL/min) is also absolute → `renal_factor = CG_CrCl/125` is dimensionally correct. Docstring warns: do **not** feed a BSA-normalized eGFR (CKD-EPI/MDRD) here.
- **`math.isfinite` guards** so `nan`/`inf` can't slip past the positivity checks and poison `renal_factor()`.
- **Two non-blocking `logging.warning`s:** age < 18 (CG unvalidated → Schwartz) and SCr < 0.6 mg/dL (low muscle mass → overestimation risk; no Jelliffe round-up, per KDIGO).
- **Documented trade-offs:** renal-only individualizes renal CL only (Vd/hepatic stay at reference); actual-weight overestimates in obesity (adjusted BW needs height — future); CG advisories go to `logging`, not the structured prediction `warnings`.

## Test plan
- [x] 18 CG tests (cancelling + non-cancelling formula anchors, both sexes, case-insensitive, 7-case validation incl. nan/inf/non-string-sex, threshold-boundary no-warn, renal-only contract, `renal_factor` integration, validation propagation). Full unit suite green locally; dependent MIPD suite (covariates+api+tdm+dosing) 84 passed.
- [x] spec → plan → subagent-driven development (per-task spec + quality review; combined Task-2 review; final holistic review = READY TO MERGE).

Spec: `docs/superpowers/specs/2026-06-12-mipd-cockcroft-gault-crcl-design.md` · Plan: `docs/superpowers/plans/2026-06-12-mipd-cockcroft-gault.md`

## Out of scope (future)
Ideal/adjusted body weight (needs height); SI µmol/L auto-conversion; Schwartz pediatric estimator; structured propagation of CG advisories into the prediction `warnings`.