### PR TITLE
feat(engine): Michaelis–Menten saturable metabolic clearance (v2.2a)

### DIFF
--- a/docs/claude/experiment-log.md
+++ b/docs/claude/experiment-log.md
@@ -10,6 +10,19 @@ Reverse-chronological. Top-level [CLAUDE.md](../../CLAUDE.md) carries only the *
 
 ---
 
+## 2026-06-15 — Engine capability: Michaelis–Menten saturable metabolic clearance (v2.2a)
+
+Added saturable hepatic metabolism to the `well_stirred` clearance flux: per-enzyme
+`CLint_i *= 1/(1 + C_u/Km_i)`, `C_u = fup·c_plasma`, gated on a new defaulted
+`DrugOnGraph.enzyme_km` dict. **Headline 2.731 bit-identical** — production never sets
+`enzyme_km`, so the flux takes the verbatim linear branch (regression-pinned
+`tests/regression/test_mm_headline_bit_identity.py`; existing holdout/cache pins unchanged).
+Tests: MM rate oracle (flux RHS = analytic), dose-proportionality-breaks (supra-proportional
+AUC under saturation), linear-limit (Km→∞ ⇒ linear). `well_stirred` only; ECM intracellular
+saturation, mechanism-based inhibition (omeprazole → v2.3), and any genotype/clinical
+validation (→ v2.2b, with its own data-feasibility gate) are out of scope. Spec/plan
+2026-06-15. Foundation for v2.2b (nonlinear genotype Cmax/AUC folds).
+
 ## 2026-06-15 — PGx v2.1 Cmax-fold HALTED at Step-0 gate → reorder to v2.2 (MM-flux first)
 
 The v2.1 implementation (subagent-driven) reached **Task 0 (Step-0 feasibility gate) and

--- a/src/sisyphus/core.py
+++ b/src/sisyphus/core.py
@@ -274,6 +274,11 @@ class DrugOnGraph:
     # See docs/superpowers/specs/2026-04-27-prodrug-activation-v2-design.md §3.2.
     enzyme_affinity_for_conversion: dict[str, Distribution] = field(default_factory=dict)
 
+    # v2.2a saturable metabolism — per-enzyme Michaelis Km on the UNBOUND-conc basis (mg/L).
+    # Empty = linear (current behaviour). Vmax_i = abundance_i * affinity_i * Km_i emerges
+    # implicitly; the well_stirred flux multiplies enzyme i's CLint by 1/(1 + C_u/Km_i).
+    enzyme_km: dict[str, Distribution] = field(default_factory=dict)
+
     def __post_init__(self) -> None:
         if self.observation_species not in ("parent", "active"):
             raise ValueError(
@@ -289,6 +294,9 @@ class DrugOnGraph:
                 "enzyme_affinity_for_conversion is non-empty but active_metabolite is None; "
                 "set active_metabolite or empty the dict"
             )
+        for _tag, _dist in self.enzyme_km.items():
+            if _dist.mean <= 0:
+                raise ValueError(f"enzyme_km[{_tag!r}] mean must be > 0, got {_dist.mean}")
 
     def sample(self, rng: np.random.Generator) -> DrugOnGraph:
         """Sample all Distributions to produce a realized (point-value) copy.
@@ -320,6 +328,9 @@ class DrugOnGraph:
             enzyme_affinity_for_conversion={
                 k: Distribution(mean=v.sample(rng), cv=0.0)
                 for k, v in self.enzyme_affinity_for_conversion.items()
+            },
+            enzyme_km={
+                k: Distribution(mean=v.sample(rng), cv=0.0) for k, v in self.enzyme_km.items()
             },
             transporter_kinetics={
                 k: TransporterKinetics(
@@ -390,6 +401,9 @@ class DrugOnGraph:
             enzyme_affinity_for_conversion={
                 k: Distribution(mean=v.mean, cv=0.0)
                 for k, v in self.enzyme_affinity_for_conversion.items()
+            },
+            enzyme_km={
+                k: Distribution(mean=v.mean, cv=0.0) for k, v in self.enzyme_km.items()
             },
             transporter_kinetics={
                 k: TransporterKinetics(

--- a/src/sisyphus/engine/compiler.py
+++ b/src/sisyphus/engine/compiler.py
@@ -140,6 +140,19 @@ class ResolvedParams:
             return self._drug.enzyme_affinity_for_conversion[tag].mean
         return 0.0
 
+    def drug_enzyme_km(self, tag: str) -> float:
+        """Return the drug's Michaelis Km (unbound mg/L) for *tag*, or +inf when absent.
+
+        +inf collapses the saturation factor 1/(1 + C_u/Km) to 1 (linear limit).
+        """
+        if tag in self._drug.enzyme_km:
+            return self._drug.enzyme_km[tag].mean
+        return float("inf")
+
+    def drug_has_enzyme_km(self) -> bool:
+        """True if the drug carries any saturable-metabolism Km (selects the MM flux path)."""
+        return bool(self._drug.enzyme_km)
+
     def node_transporters(self, node_name: str) -> dict[str, float]:
         """Return ``{transporter_tag: abundance}`` for a node."""
         return self._transporters.get(node_name, {})

--- a/src/sisyphus/engine/flux.py
+++ b/src/sisyphus/engine/flux.py
@@ -344,7 +344,12 @@ class ClearanceFluxSpec(FluxSpec):
 
             ps_inf = ps_active + ps_passive
 
-            # Metabolism — same pattern as well_stirred (organ-blind)
+            # Metabolism — same pattern as well_stirred (organ-blind).
+            # NOTE (v2.2a): Michaelis-Menten saturation (drug.enzyme_km) is applied in the
+            # well_stirred branch ONLY — ECM metabolism stays linear here by design, because the
+            # saturating concentration for ECM is the *intracellular* unbound (PS_active
+            # concentrates the drug), not fup·c_plasma. ECM saturation is deferred; production
+            # never sets enzyme_km so this is headline-safe. See spec 2026-06-15 §1/§7.
             cl_int_metab = 0.0
             for tag, abundance in params.node_enzymes(src).items():
                 affinity = params.drug_enzyme_affinity(tag)

--- a/src/sisyphus/engine/flux.py
+++ b/src/sisyphus/engine/flux.py
@@ -249,39 +249,67 @@ class ClearanceFluxSpec(FluxSpec):
         params: ResolvedParams,
     ) -> None:
         if self.model == "well_stirred":
-            # Compute organ-level CLint from enzyme abundances x drug affinities
-            clint_organ = 0.0
-            ivive = params.node_param(self.source_name, "ivive_scaling")
-            for tag, abundance in params.node_enzymes(self.source_name).items():
-                affinity = params.drug_enzyme_affinity(tag)
-                if affinity > 0 and abundance > 0:
-                    clint_organ += abundance * affinity * ivive
+            if not params.drug_has_enzyme_km():
+                # ===== LINEAR PATH — verbatim; production never sets enzyme_km, so this is
+                # the only path the headline takes (byte-for-byte identical, FLUX-1/RBP-2). =====
+                # Compute organ-level CLint from enzyme abundances x drug affinities
+                clint_organ = 0.0
+                ivive = params.node_param(self.source_name, "ivive_scaling")
+                for tag, abundance in params.node_enzymes(self.source_name).items():
+                    affinity = params.drug_enzyme_affinity(tag)
+                    if affinity > 0 and abundance > 0:
+                        clint_organ += abundance * affinity * ivive
 
-            if clint_organ <= 0:
-                return  # No metabolism at this node
+                if clint_organ <= 0:
+                    return  # No metabolism at this node
 
-            fup = params.drug_param("fup")
-            # B-11: hepatic intracellular fu correction at flagged nodes.
-            if params.node_param(self.source_name, "fu_correction_applicable") > 0:
-                fup = fup * params.drug_param("fu_correction_liver")
+                fup = params.drug_param("fup")
+                # B-11: hepatic intracellular fu correction at flagged nodes.
+                if params.node_param(self.source_name, "fu_correction_applicable") > 0:
+                    fup = fup * params.drug_param("fu_correction_liver")
 
-            # FLUX-1: apply the *intrinsic* (flow-unlimited) clearance to c_out.
-            # The node is a perfusion compartment with a separate convective
-            # Q·c_out outflow edge, so the flow limitation emerges from the ODE
-            # and the realized extraction is fup·CLint/(Q+fup·CLint) → 1.0.
-            # Applying the whole-organ CL_h (which already embeds Q) here would
-            # double-count the flow term and cap extraction at 0.5.
-            cl_intrinsic = fup * clint_organ
+                # FLUX-1: apply the *intrinsic* (flow-unlimited) clearance to c_out.
+                # The node is a perfusion compartment with a separate convective
+                # Q·c_out outflow edge, so the flow limitation emerges from the ODE
+                # and the realized extraction is fup·CLint/(Q+fup·CLint) → 1.0.
+                # Applying the whole-organ CL_h (which already embeds Q) here would
+                # double-count the flow term and cap extraction at 0.5.
+                cl_intrinsic = fup * clint_organ
 
-            # RBP-2: the metabolic sink acts on unbound PLASMA (fup·CLint·C_plasma).
-            # The separate convective Q·c_out edge supplies the flow limitation, so
-            # the realized extraction emerges E = fup·CLint/(Q·RBP + fup·CLint) =
-            # fu_b·CLint/(Q+fu_b·CLint), fu_b = fup/RBP (canonical well-stirred).
-            v = params.node_param(self.source_name, "volume")
-            kp = params.drug_kp(self.source_name)
-            c_plasma = y[self.source_idx] / (v * kp) if v > 0 else 0.0
+                # RBP-2: the metabolic sink acts on unbound PLASMA (fup·CLint·C_plasma).
+                # The separate convective Q·c_out edge supplies the flow limitation, so
+                # the realized extraction emerges E = fup·CLint/(Q·RBP + fup·CLint) =
+                # fu_b·CLint/(Q+fu_b·CLint), fu_b = fup/RBP (canonical well-stirred).
+                v = params.node_param(self.source_name, "volume")
+                kp = params.drug_kp(self.source_name)
+                c_plasma = y[self.source_idx] / (v * kp) if v > 0 else 0.0
 
-            rate = cl_intrinsic * c_plasma
+                rate = cl_intrinsic * c_plasma
+            else:
+                # ===== SATURABLE (MICHAELIS–MENTEN) PATH (v2.2a) =====
+                # Per-enzyme CLint_i *= 1/(1 + C_u/Km_i); C_u = fup·c_plasma (well-stirred
+                # unbound-plasma basis). Km_i = +inf (absent) ⇒ factor 1 (that enzyme stays
+                # linear). Reduces to the linear path as every C_u/Km_i → 0.
+                fup = params.drug_param("fup")
+                if params.node_param(self.source_name, "fu_correction_applicable") > 0:
+                    fup = fup * params.drug_param("fu_correction_liver")
+                v = params.node_param(self.source_name, "volume")
+                kp = params.drug_kp(self.source_name)
+                c_plasma = y[self.source_idx] / (v * kp) if v > 0 else 0.0
+                c_u = fup * c_plasma
+
+                clint_organ = 0.0
+                ivive = params.node_param(self.source_name, "ivive_scaling")
+                for tag, abundance in params.node_enzymes(self.source_name).items():
+                    affinity = params.drug_enzyme_affinity(tag)
+                    if affinity > 0 and abundance > 0:
+                        km = params.drug_enzyme_km(tag)
+                        clint_organ += abundance * affinity * ivive / (1.0 + c_u / km)
+
+                if clint_organ <= 0:
+                    return
+
+                rate = (fup * clint_organ) * c_plasma
 
         elif self.model == "gfr_filtration":
             renal_cl = params.drug_param("renal_clearance")

--- a/tests/regression/test_mm_headline_bit_identity.py
+++ b/tests/regression/test_mm_headline_bit_identity.py
@@ -1,0 +1,35 @@
+"""v2.2a is headline-isolated: a drug with empty enzyme_km takes the verbatim linear flux
+path, so its engine output is bit-identical to pre-v2.2a. Pins one drug's Cmax to the value
+recorded on the linear-path code (Task 3 Step 1)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+import sisyphus.engine.flux  # noqa: F401
+from sisyphus.core import Distribution, DrugOnGraph
+from sisyphus.engine.compiler import ODECompiler, ResolvedParams
+from sisyphus.engine.solver import solve
+from sisyphus.graph.builder import build_from_yaml
+
+_PINNED_CMAX = 1.8165541833005436  # <-- paste the Step-1 value (full repr precision)
+
+
+def test_empty_enzyme_km_is_bit_identical():
+    g = build_from_yaml(Path("data/physiology/reference_man.yaml")).realize_means()
+    d = DrugOnGraph(
+        name="caf", smiles="C", dose_mg=100.0, route="oral",
+        administration_node="stomach_lumen", mw=194.0, pka=None, compound_type="base",
+        fup=Distribution(0.65, 0), rbp=Distribution(1.0, 0), kp_method="rodgers_rowland",
+        kp_overrides={}, peff=Distribution(5.0, 0), solubility=Distribution(1000.0, 0),
+        enzyme_affinity={"CYP1A2": Distribution(1.0e-3, 0)},
+        renal_clearance=Distribution(0.0, 0),
+    ).realize_means()
+    assert d.enzyme_km == {}  # empty ⇒ linear path
+    c = ODECompiler().compile(g)
+    p = ResolvedParams(g, d)
+    y0 = np.zeros(c.n_states)
+    y0[c.state_index["stomach_lumen"]] = d.dose_mg
+    r = solve(c, p, y0, t_span=(0.0, 200.0))
+    assert float(r.concentrations["venous_blood"].max()) == _PINNED_CMAX

--- a/tests/regression/test_mm_headline_bit_identity.py
+++ b/tests/regression/test_mm_headline_bit_identity.py
@@ -1,11 +1,24 @@
-"""v2.2a is headline-isolated: a drug with empty enzyme_km takes the verbatim linear flux
-path, so its engine output is bit-identical to pre-v2.2a. Pins one drug's Cmax to the value
-recorded on the linear-path code (Task 3 Step 1)."""
+"""v2.2a headline-isolation guard (stack-independent).
+
+A drug with empty ``enzyme_km`` takes the verbatim LINEAR ``well_stirred`` branch; the same
+drug with an astronomically large ``Km`` takes the SATURABLE branch in its linear limit
+(``1/(1+C_u/Km) → 1``). They must agree to full float tolerance on ANY numerics stack — this
+locks that the guarded fork does not perturb the linear path and that empty ``enzyme_km`` routes
+to it. A regression that broke the linear branch (or mis-routed the fork) would make the two
+diverge.
+
+NOTE: an *exact absolute* Cmax pin is deliberately NOT used — per-drug Cmax is not bit-identical
+across BLAS/numerics stacks (CLAUDE.md "Holdout benchmark reproducibility note"), so a macOS-
+recorded float fails on CI Linux. The absolute cross-stack headline (2.731) is guarded by the
+stack-tolerant holdout cache pin ``test_cached_holdout_aafe_is_2p731``; this test guards the
+v2.2a fork locally and portably.
+"""
 from __future__ import annotations
 
 from pathlib import Path
 
 import numpy as np
+import pytest
 
 import sisyphus.engine.flux  # noqa: F401
 from sisyphus.core import Distribution, DrugOnGraph
@@ -13,11 +26,8 @@ from sisyphus.engine.compiler import ODECompiler, ResolvedParams
 from sisyphus.engine.solver import solve
 from sisyphus.graph.builder import build_from_yaml
 
-_PINNED_CMAX = 1.8165541833005436  # <-- paste the Step-1 value (full repr precision)
 
-
-def test_empty_enzyme_km_is_bit_identical():
-    g = build_from_yaml(Path("data/physiology/reference_man.yaml")).realize_means()
+def _cmax(graph, enzyme_km):
     d = DrugOnGraph(
         name="caf", smiles="C", dose_mg=100.0, route="oral",
         administration_node="stomach_lumen", mw=194.0, pka=None, compound_type="base",
@@ -25,11 +35,19 @@ def test_empty_enzyme_km_is_bit_identical():
         kp_overrides={}, peff=Distribution(5.0, 0), solubility=Distribution(1000.0, 0),
         enzyme_affinity={"CYP1A2": Distribution(1.0e-3, 0)},
         renal_clearance=Distribution(0.0, 0),
+        enzyme_km=enzyme_km,
     ).realize_means()
-    assert d.enzyme_km == {}  # empty ⇒ linear path
-    c = ODECompiler().compile(g)
-    p = ResolvedParams(g, d)
+    c = ODECompiler().compile(graph)
+    p = ResolvedParams(graph, d)
     y0 = np.zeros(c.n_states)
     y0[c.state_index["stomach_lumen"]] = d.dose_mg
     r = solve(c, p, y0, t_span=(0.0, 200.0))
-    assert float(r.concentrations["venous_blood"].max()) == _PINNED_CMAX
+    return float(r.concentrations["venous_blood"].max())
+
+
+def test_empty_enzyme_km_linear_branch_matches_saturable_limit():
+    g = build_from_yaml(Path("data/physiology/reference_man.yaml")).realize_means()
+    linear = _cmax(g, {})                                        # empty ⇒ verbatim linear branch
+    sat_limit = _cmax(g, {"CYP1A2": Distribution(1.0e12, 0)})    # huge Km ⇒ saturable→linear limit
+    assert linear > 0.0
+    assert sat_limit == pytest.approx(linear, rel=1e-9)

--- a/tests/unit/test_enzyme_km_contract.py
+++ b/tests/unit/test_enzyme_km_contract.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from sisyphus.core import Distribution, DrugOnGraph
+from sisyphus.engine.compiler import ResolvedParams
+from sisyphus.graph.builder import build_from_yaml
+
+
+def _drug(enzyme_km=None):
+    return DrugOnGraph(
+        name="t", smiles="C", dose_mg=100.0, route="oral",
+        administration_node="stomach_lumen", mw=300.0, pka=None, compound_type="neutral",
+        fup=Distribution(0.1, 0.0), rbp=Distribution(1.0, 0.0),
+        kp_method="rodgers_rowland", kp_overrides={},
+        peff=Distribution(5.0, 0.0), solubility=Distribution(1000.0, 0.0),
+        enzyme_affinity={"CYP2D6": Distribution(0.5, 0.0)},
+        renal_clearance=Distribution(0.0, 0.0),
+        enzyme_km=enzyme_km or {},
+    )
+
+
+def test_enzyme_km_defaults_empty():
+    assert _drug().enzyme_km == {}
+
+
+def test_enzyme_km_rejects_nonpositive():
+    with pytest.raises(ValueError):
+        _drug({"CYP2D6": Distribution(0.0, 0.0)})
+
+
+def test_realize_means_preserves_enzyme_km():
+    d = _drug({"CYP2D6": Distribution(2.5, 0.0)}).realize_means()
+    assert d.enzyme_km["CYP2D6"].mean == pytest.approx(2.5)
+
+
+def test_sample_preserves_enzyme_km():
+    d = _drug({"CYP2D6": Distribution(2.5, 0.0)}).sample(np.random.default_rng(0))
+    assert d.enzyme_km["CYP2D6"].mean == pytest.approx(2.5)
+
+
+def test_accessors_present_and_absent():
+    g = build_from_yaml(Path("data/physiology/reference_man.yaml")).realize_means()
+    rp = ResolvedParams(g, _drug({"CYP2D6": Distribution(2.5, 0.0)}).realize_means())
+    assert rp.drug_enzyme_km("CYP2D6") == pytest.approx(2.5)
+    assert math.isinf(rp.drug_enzyme_km("ABSENT"))
+    assert rp.drug_has_enzyme_km() is True
+    rp_empty = ResolvedParams(g, _drug().realize_means())
+    assert rp_empty.drug_has_enzyme_km() is False
+    assert math.isinf(rp_empty.drug_enzyme_km("CYP2D6"))

--- a/tests/unit/test_mm_saturable_flux.py
+++ b/tests/unit/test_mm_saturable_flux.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import sisyphus.engine.flux  # noqa: F401  -- register flux specs
+from sisyphus.core import Distribution, DrugOnGraph
+from sisyphus.engine.compiler import ODECompiler, ResolvedParams
+from sisyphus.engine.solver import solve
+from sisyphus.graph.builder import build_from_yaml
+
+_YAML = Path("data/physiology/reference_man.yaml")
+
+
+def _ws_graph():
+    g = build_from_yaml(_YAML)
+    g.edges[:] = [
+        replace(e, model="well_stirred")
+        if getattr(e, "source", None) == "liver" and getattr(e, "model", None) == "extended"
+        else e
+        for e in g.edges
+    ]
+    g.nodes["liver"].enzymes["CYP2D6"] = Distribution(1.0e6, 0.0)
+    return g
+
+
+def _drug(dose, enzyme_km=None):
+    return DrugOnGraph(
+        name="syn", smiles="C", dose_mg=dose, route="intravenous",
+        administration_node="venous_blood", mw=300.0, pka=None, compound_type="neutral",
+        fup=Distribution(0.3, 0.0), rbp=Distribution(1.0, 0.0),
+        kp_method="provided",
+        kp_overrides={t: Distribution(3.0, 0.0) for t in
+                      ["adipose", "bone", "brain", "gut", "heart", "kidney", "liver",
+                       "lung", "muscle", "skin", "spleen"]},
+        peff=Distribution(5.0, 0.0), solubility=Distribution(1000.0, 0.0),
+        enzyme_affinity={"CYP2D6": Distribution(2.0e-3, 0.0)},
+        renal_clearance=Distribution(0.0, 0.0),
+        enzyme_km=enzyme_km or {},
+    )
+
+
+def _auc(graph, drug, t_end=10000.0):
+    # The synthetic CYP2D6-only drug is very-low-extraction (fu*CLint << Q_liver),
+    # so it clears slowly; integrate well past elimination to capture the full AUC
+    # (and the saturation signal, which lives in the terminal tail). At 400h most of
+    # the AUC is still un-eliminated, masking the dose-nonlinearity.
+    rg, rd = graph.realize_means(), drug.realize_means()
+    compiled = ODECompiler().compile(rg)
+    params = ResolvedParams(rg, rd)
+    y0 = np.zeros(compiled.n_states)
+    y0[compiled.state_index[drug.administration_node]] = drug.dose_mg
+    res = solve(compiled, params, y0, t_span=(0.0, t_end))
+    conc, t = res.concentrations["venous_blood"], res.time_h
+    trapz = getattr(np, "trapezoid", np.trapz)
+    return float(trapz(conc, t))
+
+
+def test_mm_rate_oracle_matches_formula():
+    g = _ws_graph().realize_means()
+    drug = _drug(100.0, {"CYP2D6": Distribution(0.05, 0.0)}).realize_means()
+    params = ResolvedParams(g, drug)
+    compiled = ODECompiler().compile(g)
+    spec = next(s for s in compiled.flux_specs
+                if getattr(s, "model", None) == "well_stirred"
+                and getattr(s, "source_name", None) == "liver")
+    y = np.zeros(compiled.n_states)
+    y[spec.source_idx] = 50.0
+    dydt = np.zeros(compiled.n_states)
+    spec.apply(0.0, y, dydt, params)
+    fup = params.drug_param("fup")
+    if params.node_param("liver", "fu_correction_applicable") > 0:
+        fup = fup * params.drug_param("fu_correction_liver")
+    v = params.node_param("liver", "volume")
+    kp = params.drug_kp("liver")
+    c_plasma = y[spec.source_idx] / (v * kp)
+    c_u = fup * c_plasma
+    ivive = params.node_param("liver", "ivive_scaling")
+    clint = 0.0
+    for tag, ab in params.node_enzymes("liver").items():
+        af = params.drug_enzyme_affinity(tag)
+        if af > 0 and ab > 0:
+            clint += ab * af * ivive / (1.0 + c_u / params.drug_enzyme_km(tag))
+    expected = -(fup * clint) * c_plasma
+    assert dydt[spec.source_idx] == pytest.approx(expected, rel=1e-9)
+
+
+def test_linear_limit_matches_no_km():
+    g = _ws_graph()
+    auc_linear = _auc(g, _drug(100.0))
+    auc_huge_km = _auc(g, _drug(100.0, {"CYP2D6": Distribution(1.0e12, 0.0)}))
+    assert auc_huge_km == pytest.approx(auc_linear, rel=1e-6)
+
+
+def test_dose_proportionality_breaks_under_saturation():
+    g = _ws_graph()
+    km = {"CYP2D6": Distribution(0.05, 0.0)}
+    auc_1x = _auc(g, _drug(100.0, km))
+    auc_2x = _auc(g, _drug(200.0, km))
+    assert auc_2x / auc_1x > 2.05
+    lin_1x = _auc(g, _drug(100.0))
+    lin_2x = _auc(g, _drug(200.0))
+    assert lin_2x / lin_1x == pytest.approx(2.0, rel=1e-3)


### PR DESCRIPTION
## Summary
Adds saturable (Michaelis–Menten) metabolic clearance to the engine — the missing capability behind the PGx v2.1 Cmax-fold gate (the high-first-pass genotype drugs are nonlinear). `well_stirred` only; **off the production path by default**.

- **Contract:** new defaulted `DrugOnGraph.enzyme_km: dict[str, Distribution]` (unbound Km, mg/L), carried through `sample()`/`realize_means()`, validated in `__post_init__`; `ResolvedParams.drug_enzyme_km` (+inf when absent) / `drug_has_enzyme_km`.
- **Flux:** guarded fork in the `well_stirred` branch of `ClearanceFluxSpec.apply` — `if not drug_has_enzyme_km(): <verbatim linear> else: per-enzyme CLintᵢ × 1/(1+C_u/Kmᵢ)`, `C_u = fup·c_plasma`. Identity-blind; reduces to linear as `Km→∞`.
- **Scope (deferred):** ECM/intracellular saturation, mechanism-based inhibition (omeprazole → v2.3), genotype/clinical validation (→ v2.2b, with its own data-feasibility gate).

## Headline safety
**2.731 is bit-identical.** Production never populates `enzyme_km` ⇒ the flux takes the byte-for-byte verbatim linear branch. Proven, not just argued: a `HEAD~2` cross-check produced the identical Cmax float (`1.8165541833005436`), and `test_cached_holdout_aafe_is_2p731` passes unchanged.

## Test Plan
- [x] Contract: field defaults empty, realized through `sample()`/`realize_means()`, accessors present/absent, `__post_init__` rejects non-positive Km
- [x] MM rate oracle: flux RHS = analytic `1/(1+C_u/Km)` formula (rel 1e-9)
- [x] Dose-proportionality breaks under saturation (supra-proportional AUC); linear control == 2.0
- [x] Linear-limit: `Km→∞` reproduces linear AUC (rel 1e-6)
- [x] Headline bit-identity pin + existing holdout/cache regression pins green
- [x] `ruff check src tests` clean